### PR TITLE
1552 deprecate activity

### DIFF
--- a/src/data/valid/Database-img_mg_annotation_objects.yaml
+++ b/src/data/valid/Database-img_mg_annotation_objects.yaml
@@ -1,4 +1,4 @@
-activity_set:
+workflow_execution_set:
 - has_input:
   - nmdc:b4b798cc9e7e9253ae8256a8237fd371
   git_url: https://img.jgi.doe.gov

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -592,7 +592,7 @@ slots:
     description: Links a resource to another resource that either logically or physically includes it.
   
   execution_resource:
-    domain: Activity
+    domain: WorkflowExecutionActivity
     range: string
 #    is_a: attribute
     examples:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -216,8 +216,7 @@ classes:
       - read_based_taxonomy_analysis_activity_set
       - read_qc_analysis_activity_set
       - study_set
-
-
+      - workflow_execution_set
 
   Pooling:
     class_uri: nmdc:Pooling

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -192,7 +192,6 @@ classes:
       #      - material_sample_set
       #      - material_sampling_activity_set
       #      - reaction_activity_set
-      - activity_set
       - biosample_set
       - collecting_biosamples_from_site_set
       - data_object_set

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2766,7 +2766,7 @@ slots:
     description:
       This property links a database object to the set of all functional
       annotations
-  workflow_execution_activity_set:
+  workflow_execution_set:
     domain: Database # not inherited byt mixin users
     mixins: object_set
     range: WorkflowExecutionActivity

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2767,6 +2767,11 @@ slots:
     description:
       This property links a database object to the set of all functional
       annotations
+  workflow_execution_activity_set:
+    domain: Database # not inherited byt mixin users
+    mixins: object_set
+    range: WorkflowExecutionActivity
+    description: This property links a database object to the set of workflow activities.
   mags_activity_set:
     domain: Database # not inherited byt mixin users
     mixins: object_set

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2767,11 +2767,6 @@ slots:
     description:
       This property links a database object to the set of all functional
       annotations
-  activity_set:
-    domain: Database # not inherited byt mixin users
-    mixins: object_set
-    range: WorkflowExecutionActivity
-    description: This property links a database object to the set of workflow activities.
   mags_activity_set:
     domain: Database # not inherited byt mixin users
     mixins: object_set

--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -21,7 +21,7 @@ classes:
 slots:
 
   started_at_time:
-    domain: Activity
+    domain: WorkflowExecutionActivity
     range: string
     #    range: datetime
     pattern: ^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$
@@ -32,7 +32,7 @@ slots:
       - prov:startedAtTime
 
   ended_at_time:
-    domain: Activity
+    domain: WorkflowExecutionActivity
     #    range: datetime
     pattern: ^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$
     notes: >-
@@ -42,17 +42,17 @@ slots:
       - prov:endedAtTime
 
   was_informed_by:
-    domain: Activity
-    range: Activity
+    domain: WorkflowExecutionActivity
+    range: WorkflowExecutionActivity
     mappings:
       - prov:wasInformedBy
 
   was_generated_by:
-    range: Activity
+    range: WorkflowExecutionActivity
     mappings:
       - prov:wasGeneratedBy
 
   used:
-    domain: Activity
+    domain: WorkflowExecutionActivity
     mappings:
       - prov:used

--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -18,29 +18,6 @@ default_range: string
 
 classes:
 
-  Activity:
-    description: Something that occurs over a period of time and acts upon or with entities; 
-      it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.
-    slots:
-      - id
-      - name
-      - started_at_time
-      - ended_at_time
-      - was_informed_by
-      - used
-    comments:
-      - to be replaced with PlannedProcess in the monterey-schema
-    notes:
-      - removed was_associated_with because we are trying to avoid instantiating id-less Agents
-    mappings:
-      - prov:Activity
-    slot_usage:
-      id:
-        required: true
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:act-{id_shoulder}-{id_blade}{id_version}{id_locus}"
-          interpolated: true
-
 slots:
 
   started_at_time:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -27,7 +27,7 @@ classes:
     aliases:
       - analysis
     comments:
-      - Each instance of this (and all other) activities is  a distinct run with start and stop times, potentially with different inputs and outputs
+      - Each instance of this (and all other) subclasses of WorkflowExecution is a distinct run with start and stop times, potentially with different inputs and outputs
     in_subset:
       - workflow subset
     description: >-

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -37,6 +37,12 @@ classes:
       embl.ena: >-
         An analysis contains secondary analysis results derived from sequence reads (e.g. a genome assembly)
     slots:
+      - id
+      - name
+      - started_at_time
+      - ended_at_time
+      - was_informed_by
+      - used
       - execution_resource
       - git_url
       - has_input

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -28,7 +28,6 @@ classes:
       - analysis
     comments:
       - Each instance of this (and all other) activities is  a distinct run with start and stop times, potentially with different inputs and outputs
-    is_a: Activity
     in_subset:
       - workflow subset
     description: >-

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -560,5 +560,5 @@ slots:
     multivalued: true
 
   version:
-    domain: Activity
+    domain: WorkflowExecutionActivity
     range: string


### PR DESCRIPTION
Regarding issue: https://github.com/microbiomedata/nmdc-schema/issues/1552

- Remove the `Activity` class from the schema
- Move `Activity` slots over to `WorkflowExecutionActivity` class
- change `activity_set` slot for the `Database` class to `workflow_execution_set`
- Change references like `domain` and `range` values from `Activity` to `WorkflowExecutionActivity`