### PR TITLE
Update has_output slot description

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -580,7 +580,7 @@ slots:
     domain: NamedThing
     range: NamedThing
     multivalued: true
-    description: An output biosample to a processing step
+    description: An output from a process.
 
   part_of:
     aliases:


### PR DESCRIPTION
This PR provides an update to the description of the has_output slot to remove any reference to specific output e.g. biosample