### PR TITLE
Add rules to `ChromatographicSeparationProcess` so `has_calibration` is required if `chromatographic_category` is gc

### DIFF
--- a/src/data/invalid/ChromatographicSeparationProcess-no_has_calibration_with_GC.yaml
+++ b/src/data/invalid/ChromatographicSeparationProcess-no_has_calibration_with_GC.yaml
@@ -25,4 +25,3 @@ ordered_mobile_phases:
     has_solution_components:
       - compound: water
 chromatographic_category: gas_chromatography
-has_calibration: nmdc:obj-asdfasd-asdfasdf

--- a/src/data/valid/ChromatographicSeparationProcess-GC-has_calibration.yaml
+++ b/src/data/valid/ChromatographicSeparationProcess-GC-has_calibration.yaml
@@ -1,0 +1,28 @@
+id: nmdc:cspro-99-oW43DzG0 
+has_input: 
+  - nmdc:procsm-11-9gjxns61
+has_output:
+  - nmdc:procsm-11-05g48p90
+  - nmdc:procsm-11-05g48p91
+stationary_phase: "CN"
+ordered_mobile_phases:
+  - volume:
+      has_numeric_value: 700
+      has_unit: mL
+    has_solution_components:
+      - compound: methanol
+  - volume:
+      has_numeric_value: 700
+      has_unit: mL
+    has_solution_components:
+      - compound: hydrochloric_acid
+        concentration:
+          has_numeric_value: 10
+          has_unit: mM 
+  - volume:
+      has_numeric_value: 1000
+      has_unit: mL  
+    has_solution_components:
+      - compound: water
+chromatographic_category: GC
+has_calibration: nmdc:obj-asdfasd-asdfasdf

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1752,11 +1752,11 @@ classes:
     rules:
       - title: has_calibration_required_if_gc
         description: >-
-          If chromatographic_category is GC, then has_calibration is required.
+          If chromatographic_category is gas_chromatography, then has_calibration is required.
         preconditions:
           slot_conditions:
             chromatographic_category:
-              equals_string: GC
+              equals_string: gas_chromatography
         postconditions:
           slot_conditions:
             has_calibration:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1745,10 +1745,22 @@ classes:
     is_a: FluidHandling
     slots:
       - has_calibration
-      - chromatrographic_category
+      - chromatographic_category
       - ordered_mobile_phases
       - stationary_phase
       - temperature
+    rules:
+      - title: has_calibration_required_if_gc
+        description: >-
+          If chromatographic_category is GC, then has_calibration is required.
+        preconditions:
+          slot_conditions:
+            chromatographic_category:
+              equals_string: GC
+        postconditions:
+          slot_conditions:
+            has_calibration:
+              required: true
     slot_usage:
       id:
         required: true
@@ -3541,7 +3553,7 @@ slots:
     domain: ChromatographicSeparationProcess
     range: StationaryPhaseEnum
     description: The material the stationary phase is comprised of used in chromatography.
-  chromatrographic_category:
+  chromatographic_category:
     domain: ChromatographicSeparationProcess
     range: ChromatographicCategoryEnum
     description: The type of chromatography used in a process.


### PR DESCRIPTION
For issue https://github.com/microbiomedata/nmdc-schema/issues/1570#issuecomment-1858124456

Add rule to `ChromatographicSeparationProcess` that specifies that if `chromatographic_category` is `gas_chromatography` then `has_calibration` is required.