### PR TITLE
Update WorkflowExecution model to remove multivalued: false slot_usage on part_of

### DIFF
--- a/src/data/invalid/Database-MetabolomicAnalysis_part_of_not_array.yaml
+++ b/src/data/invalid/Database-MetabolomicAnalysis_part_of_not_array.yaml
@@ -4,8 +4,7 @@ metabolomics_analysis_set:
     started_at_time: '2021-08-05T14:48:51+00:00'
     ended_at_time: '2021-09-15T10:13:20+00:00'
     execution_resource: NERSC-Cori
-    part_of:
-      - nmdc:wfch-11-ab
+    part_of: nmdc:wfch-11-ab
     git_url: https://example.org/WorkflowExecutionActivity
     has_input:
       - nmdc:i1

--- a/src/data/invalid/Database-WorkflowChain_WorkflowExecution_no_part_of.yaml
+++ b/src/data/invalid/Database-WorkflowChain_WorkflowExecution_no_part_of.yaml
@@ -1,0 +1,24 @@
+workflow_chain_set:
+  - id: nmdc:wfch-11-ab
+    analyte_category: metagenome
+    was_informed_by: nmdc:datgen-11-s9xj2r24
+    type: nmdc:WorkflowChain
+  - id: nmdc:wfch-12-cd
+    analyte_category: metagenome
+    was_informed_by: nmdc:datgen-11-s9xj2r24
+    type: nmdc:WorkflowChain
+read_qc_analysis_set:
+  - id: nmdc:wfrqc-12-63da5n74
+    name: 'TEST Read QC Activity for nmdc:wfrqc-12-63da5n74 '
+    started_at_time: '2023-03-23T17:17:05.111689+00:00'
+    ended_at_time: '2023-03-23T17:17:05.111725+00:00'
+    execution_resource: NERSC-Cori
+    git_url: https://github.com/microbiomedata/ReadsQC
+    has_input:
+      - nmdc:dobj-12-jdhk9537
+      - nmdc:dobj-12-yx0tfp52
+    has_output:
+      - nmdc:dobj-12-71q7wv80
+      - nmdc:dobj-12-y236qp68
+    type: nmdc:ReadQcAnalysis
+    version: b1.0.7

--- a/src/data/valid/Database-WorkflowChain-WorkflowExecution.yaml
+++ b/src/data/valid/Database-WorkflowChain-WorkflowExecution.yaml
@@ -1,0 +1,27 @@
+workflow_chain_set:
+  - id: nmdc:wfch-11-ab
+    analyte_category: metagenome
+    was_informed_by: nmdc:datgen-11-s9xj2r24
+    type: nmdc:WorkflowChain
+  - id: nmdc:wfch-12-cd
+    analyte_category: metagenome
+    was_informed_by: nmdc:datgen-11-s9xj2r24
+    type: nmdc:WorkflowChain
+read_qc_analysis_set:
+  - id: nmdc:wfrqc-12-63da5n74
+    name: 'TEST Read QC Activity for nmdc:wfrqc-12-63da5n74 '
+    started_at_time: '2023-03-23T17:17:05.111689+00:00'
+    ended_at_time: '2023-03-23T17:17:05.111725+00:00'
+    part_of:
+      - nmdc:wfch-11-ab
+      - nmdc:wfch-12-cd
+    execution_resource: NERSC-Cori
+    git_url: https://github.com/microbiomedata/ReadsQC
+    has_input:
+      - nmdc:dobj-12-jdhk9537
+      - nmdc:dobj-12-yx0tfp52
+    has_output:
+      - nmdc:dobj-12-71q7wv80
+      - nmdc:dobj-12-y236qp68
+    type: nmdc:ReadQcAnalysis
+    version: b1.0.7

--- a/src/data/valid/Database-mags.yaml
+++ b/src/data/valid/Database-mags.yaml
@@ -2,7 +2,8 @@ mags_set:
   - id: nmdc:wfmag-99-5MiDJM
     type: nmdc:MagsAnalysis
     name: MAGs activiity 1781_86101
-    part_of: nmdc:wfch-11-ab
+    part_of:
+      - nmdc:wfch-11-ab
     started_at_time: '2021-01-10T00:00:00+00:00'
     ended_at_time: '2021-01-10T00:00:00+00:00'
     execution_resource: NERSC-Cori
@@ -58,7 +59,8 @@ mags_set:
 
   - id: nmdc:wfmag-99-VOgM5i
     name: MAGs activiity 1781_86089
-    part_of: nmdc:wfch-12-ab
+    part_of:
+      - nmdc:wfch-12-ab
     started_at_time: '2021-01-10T00:00:00+00:00'
     ended_at_time: '2021-01-10T00:00:00+00:00'
     type: nmdc:MagsAnalysis

--- a/src/data/valid/Database-metagenome-assembly.yaml
+++ b/src/data/valid/Database-metagenome-assembly.yaml
@@ -2,7 +2,8 @@ metagenome_assembly_set:
   - id: nmdc:wfmgas-99-B7Vogx
     type: nmdc:MetagenomeAssembly
     name: Metagenome assembly 1472_51277
-    part_of: nmdc:wfch-11-ab
+    part_of:
+      - nmdc:wfch-11-ab
     started_at_time: '2020-03-24T00:00:00+00:00'
     ended_at_time: '2020-03-25T00:00:00+00:00'
     execution_resource: LANL-B-div
@@ -45,10 +46,10 @@ metagenome_assembly_set:
   - id: nmdc:wfmgas-99-CvgXTq
     type: nmdc:MetagenomeAssembly
     name: Metagenome assembly 1472_51278
-    part_of: nmdc:wfch-11-ab
+    part_of:
+      - nmdc:wfch-11-ab
     started_at_time: '2020-03-25T00:00:00+00:00'
     ended_at_time: '2020-03-25T00:00:00+00:00'
-    type: nmdc:MetagenomeAssembly
     execution_resource: LANL-B-div
     git_url: https://github.com/microbiomedata/metaAssembly/releases/tag/1.0.0
     has_input:
@@ -89,7 +90,8 @@ metagenome_assembly_set:
   - id: nmdc:wfmgas-99-L9Z34K
     type: nmdc:MetagenomeAssembly
     name: Metagenome assembly 1472_51279
-    part_of: nmdc:wfch-11-ab
+    part_of:
+      - nmdc:wfch-11-ab
     started_at_time: '2020-03-25T00:00:00+00:00'
     ended_at_time: '2020-03-25T00:00:00+00:00'
     execution_resource: LANL-B-div

--- a/src/data/valid/Database-neon_Biosample_to_DataObject_NEON.yaml
+++ b/src/data/valid/Database-neon_Biosample_to_DataObject_NEON.yaml
@@ -141,7 +141,8 @@ read_qc_analysis_set:
     name: 'TEST Read QC Activity for nmdc:wfrqc-12-63da5n74 '
     started_at_time: '2023-03-23T17:17:05.111689+00:00'
     ended_at_time: '2023-03-23T17:17:05.111725+00:00'
-    part_of: nmdc:wfch-11-ab
+    part_of:
+      - nmdc:wfch-11-ab
     execution_resource: NERSC-Cori
     git_url: https://github.com/microbiomedata/ReadsQC
     has_input:

--- a/src/data/valid/Database-nom_analysis_set.yaml
+++ b/src/data/valid/Database-nom_analysis_set.yaml
@@ -11,4 +11,5 @@ nom_analysis_set:
       - nmdc:4
     started_at_time: "2018-11-13T20:20:39+00:00"
     ended_at_time: "2018-11-13T20:20:39+00:00"
-    part_of: nmdc:wfch-99-abcdefg
+    part_of:
+      - nmdc:wfch-99-abcdefg

--- a/src/data/valid/Database-with-MetagenomeSequencing.yaml
+++ b/src/data/valid/Database-with-MetagenomeSequencing.yaml
@@ -5,7 +5,8 @@ metagenome_sequencing_set:
       - 'nmdc:unvalidated_placeholder'
     # legacy part_of id? validator won't catch pattern violations
     #   or referential integrity violations
-    part_of: nmdc:wfch-11-ab
+    part_of:
+      - nmdc:wfch-11-ab
     git_url: 'https://github.com/microbiomedata/RawSequencingData'
     execution_resource: JGI
     version: v1.0.0

--- a/src/data/valid/MetabolomicsAnalysis-1.yaml
+++ b/src/data/valid/MetabolomicsAnalysis-1.yaml
@@ -3,7 +3,8 @@ type: nmdc:MetabolomicsAnalysis
 started_at_time: '2021-08-05T14:48:51+00:00'
 ended_at_time: '2021-09-15T10:13:20+00:00'
 execution_resource: NERSC-Cori
-part_of: nmdc:wfch-11-ab
+part_of:
+    - nmdc:wfch-11-ab
 git_url: https://example.org/WorkflowExecutionActivity
 has_input:
   - nmdc:i1

--- a/src/data/valid/MetagenomeSequencing-from-metagenome_seequencing_json.yaml
+++ b/src/data/valid/MetagenomeSequencing-from-metagenome_seequencing_json.yaml
@@ -4,7 +4,8 @@ has_input:
   - 'nmdc:unvalidated_placeholder'
 # legacy part_of id? validator won't catch pattern violations
 #   or referential integrity violations
-part_of: nmdc:wfch-11-ab
+part_of:
+    - nmdc:wfch-11-ab
 git_url: 'https://github.com/microbiomedata/RawSequencingData'
 execution_resource: JGI
 version: v1.0.0

--- a/src/data/valid/ReadQcAnalysis-1.yaml
+++ b/src/data/valid/ReadQcAnalysis-1.yaml
@@ -11,7 +11,8 @@ output_base_count: 100.0
 output_read_bases: 100.0
 output_read_count: 3.0
 started_at_time: '2021-08-05T14:48:51+00:00'
-part_of: "nmdc:wfch-11-ab"
+part_of:
+  - "nmdc:wfch-11-ab"
 has_input:
   - "jgi:534819030d87850d7aea2a16"
 has_output:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -93,7 +93,6 @@ classes:
         description: >-
           The WorkflowChain that this WorkflowExecution is part of
         range: WorkflowChain
-        multivalued: false
       id:
         required: true
         structured_pattern:


### PR DESCRIPTION
This PR addressed 2 duplicate tickets:
#1587 
#1583 
and provides:
- Update to WorkflowExecution.part_of to remove incorrect `multivalued: false` usage directive
- Update valid data examples to ensure WorkflowExecutions part_of data is an array
- Add to invalid data examples:  No part_of slot, and part_of not an array