### PR TITLE
1581 keep omprc typecode for class Data Generation

### DIFF
--- a/src/data/invalid/DataGeneration-invalid-prefix.yaml
+++ b/src/data/invalid/DataGeneration-invalid-prefix.yaml
@@ -1,0 +1,19 @@
+#invalid id prefix
+id: nmdc:omicsprc-99-zUCd5N
+type: nmdc:DataGeneration
+analyte_category: metagenome
+alternative_identifiers:
+  - gold:Gp0108335
+name: Thawing permafrost microbial communities from the Arctic, studying carbon
+  transformations - Permafrost 712P3D
+has_input:
+  - nmdc:bsm-00-red
+add_date: 30-OCT-14 12.00.00.000000000 AM
+mod_date: 22-MAY-20 06.13.12.927000000 PM
+has_output:
+  - nmdc:dobj-00-9n9n9n
+ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
+  carbon transformations - Permafrost 712P3D
+part_of:
+  - nmdc:sty-00-555xxx
+processing_institution: JGI

--- a/src/data/valid/DataGeneration-2.yaml
+++ b/src/data/valid/DataGeneration-2.yaml
@@ -1,0 +1,19 @@
+#test to check readding prefix 'omprc' as a valid id pattern
+id: nmdc:omprc-99-zUCd5N
+type: nmdc:DataGeneration
+analyte_category: metagenome
+alternative_identifiers:
+  - gold:Gp0108335
+name: Thawing permafrost microbial communities from the Arctic, studying carbon
+  transformations - Permafrost 712P3D
+has_input:
+  - nmdc:bsm-00-red
+add_date: 30-OCT-14 12.00.00.000000000 AM
+mod_date: 22-MAY-20 06.13.12.927000000 PM
+has_output:
+  - nmdc:dobj-00-9n9n9n
+ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
+  carbon transformations - Permafrost 712P3D
+part_of:
+  - nmdc:sty-00-555xxx
+processing_institution: JGI

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1865,7 +1865,7 @@ classes:
       id:
         required: true
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:datgen-{id_shoulder}-{id_blade}{id_version}{id_locus}"
+          syntax: "{id_nmdc_prefix}:(datgen|omprc)-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
       has_input:
         required: true


### PR DESCRIPTION
PR to keep omprc as a valid type code for DataGeneration so we don't have to re-id records just because we've changed the class name.