### PR TITLE
fix data generation example file id error

### DIFF
--- a/src/data/valid/DataGeneration-2.yaml
+++ b/src/data/valid/DataGeneration-2.yaml
@@ -15,5 +15,5 @@ has_output:
 ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
   carbon transformations - Permafrost 712P3D
 part_of:
-  - nmdc:sty-00-555xxx
+  - nmdc:datgen-00-555xxx
 processing_institution: JGI


### PR DESCRIPTION
This example data file went uncaught when I created the `part_of` relationship for `DataGeneration`. The id for `part_of` should be a data generation id, not a study.