### PR TITLE
1566- add permissible values to InstrumentVendorEnum and InstrumentModelEnum for sequencing applications

### DIFF
--- a/src/data/valid/Database-instrument_set.yaml
+++ b/src/data/valid/Database-instrument_set.yaml
@@ -2,7 +2,7 @@ instrument_set:
   - id: nmdc:inst-12-dtTMNb
     name: Illumina NovaSeq
     vendor: illumina
-    model: novaseq
+    model: novaseq_6000
     type: nmdc:Instrument
   - id: nmdc:inst-12-dtTMN3
     name: my favorite Orbitrap

--- a/src/data/valid/Instrument-basic.yaml
+++ b/src/data/valid/Instrument-basic.yaml
@@ -2,4 +2,4 @@ id: nmdc:inst-12-dtTMNb
 type: nmdc:Instrument
 name: Illumina NovaSeq
 vendor: illumina
-model: novaseq
+model: novaseq_6000

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -45,7 +45,6 @@ prefixes:
   FBcv: "http://purl.obolibrary.org/obo/FBcv_"
   FMA: "http://purl.obolibrary.org/obo/FMA_"
   GO: "http://purl.obolibrary.org/obo/GO_"
-  BAO: "http://purl.obolibrary.org/obo/BAO_"
   HMDB: "https://bioregistry.io/hmdb:" # https://bioregistry.io/hmdb:HMDB00001
   ISA: http://example.org/isa/
   KEGG.ORTHOLOGY: "https://bioregistry.io/kegg.orthology:"  # https://github.com/prefixcommons/biocontext/blob/master/registry/idot_context.jsonld
@@ -2198,7 +2197,7 @@ enums:
       illumina:
         aliases:
           - Illumina
-        meaning: BAO:0200000
+        meaning: OBI:0000759
       pacbio:
         aliases:
           - PacBio

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -45,6 +45,7 @@ prefixes:
   FBcv: "http://purl.obolibrary.org/obo/FBcv_"
   FMA: "http://purl.obolibrary.org/obo/FMA_"
   GO: "http://purl.obolibrary.org/obo/GO_"
+  BAO: "http://purl.obolibrary.org/obo/BAO_"
   HMDB: "https://bioregistry.io/hmdb:" # https://bioregistry.io/hmdb:HMDB00001
   ISA: http://example.org/isa/
   KEGG.ORTHOLOGY: "https://bioregistry.io/kegg.orthology:"  # https://github.com/prefixcommons/biocontext/blob/master/registry/idot_context.jsonld

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2131,7 +2131,7 @@ enums:
       miniseq:
         aliases:
           - Illumina MiniSeq
-        exactly_mappings:
+        exact_mappings:
           - OBI:0003114
       nextseq_1000:
         aliases:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2087,9 +2087,103 @@ enums:
       vortex_genie_2:
         aliases:
           - VortexGenie2
-      novaseq:
+      novaseq_6000:
         aliases:
           - NovaSeq
+          - NovaSeq 6000
+        exact_mappings:
+          - OBI:0002630
+      hiseq_1000:
+        aliases:
+          - Illumina HiSeq 1000
+        exact_mappings:
+          - OBI:0002022
+      hiseq_1500:
+        aliases:
+          - Illumina HiSeq 1500
+        exact_mappings:
+          - OBI:0003386
+      hiseq_2000:
+        aliases:
+          - Illumina HiSeq 2000
+        exact_mappings:
+          - OBI:0002001
+      hiseq_2500:
+        aliases:
+          - Illumina HiSeq 2500
+        exact_mappings:
+          - OBI:0002002
+      hiseq_3000:
+        aliases:
+          - Illumina HiSeq 3000
+        exact_mappings:
+         - OBI:0002048
+      hiseq_4000:
+        aliases:
+          - Illumina HiSeq 4000
+        exact_mappings:
+          - OBI:0002049
+      hiseq_x_ten:
+        aliases:
+          - Illumina HiSeq X Ten
+        exact_mappings:
+           - OBI:0002129
+      miniseq:
+        aliases:
+          - Illumina MiniSeq
+        exactly_mappings:
+          - OBI:0003114
+      nextseq_1000:
+        aliases:
+          - Illumina NextSeq 1000
+        exact_mappings:
+          - OBI:0003606
+      miseq:
+        aliases:
+          - MiSeq
+          - Illumina MiSeq
+        exact_mappings:
+          - OBI:0002003
+      nextseq_500:
+        aliases:
+          - NextSeq 500
+        exact_mappings:
+          - OBI:0002021
+      nextseq_550:
+        aliases:
+          - NextSeq 550
+        exact_mappings:
+          - OBI:0003387
+      gridion:
+         aliases:
+           - Oxford Nanopore GridION Mk1
+         exact_mappings:
+           - OBI:0002751
+      minion:
+        aliases:
+          - Oxford Nanopore MinION
+        exact_mappings:
+          - OBI:0002750
+      promethion:
+        aliases:
+          - Oxford Nanopore PromethION
+        exact_mappings:
+          - OBI:0002752
+      rs_II:
+        aliases:
+          - PacBio RS II
+        exact_mappings:
+          - OBI:0002012
+      sequel:
+        aliases:
+          - PacBio Sequel
+        exact_mappings:
+          - OBI:0002632
+      sequel_II:
+         aliases:
+           - PacBio Sequel II
+         exact_mappings:
+           - OBI:0002633
 
   InstrumentVendorEnum:
     permissible_values:
@@ -2120,6 +2214,18 @@ enums:
           - Illumina
         exact_mappings:
           - BAO:0200000
+          - OBI:0000759
+      pacbio:
+        aliases:
+          - PacBio
+          - Pacific Biosciences
+        exact_mappings:
+          - OBI:0001856
+      oxford_nanopore:
+        aliases:
+          - Oxford Nanopore Technologies
+        exact_mappings:
+          - OBI:0002755
 
   StatusEnum:
     permissible_values:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2091,99 +2091,84 @@ enums:
         aliases:
           - NovaSeq
           - NovaSeq 6000
-        exact_mappings:
-          - OBI:0002630
+        meaning: OBI:0002630
       hiseq_1000:
         aliases:
           - Illumina HiSeq 1000
-        exact_mappings:
-          - OBI:0002022
+        meaning: OBI:0002022
       hiseq_1500:
         aliases:
           - Illumina HiSeq 1500
-        exact_mappings:
-          - OBI:0003386
+        meaning: OBI:0003386
       hiseq_2000:
         aliases:
           - Illumina HiSeq 2000
-        exact_mappings:
-          - OBI:0002001
+        meaning: OBI:0002001
       hiseq_2500:
         aliases:
           - Illumina HiSeq 2500
-        exact_mappings:
-          - OBI:0002002
+        meaning: OBI:0002002
       hiseq_3000:
         aliases:
           - Illumina HiSeq 3000
-        exact_mappings:
-         - OBI:0002048
+        meaning: OBI:0002048
       hiseq_4000:
         aliases:
           - Illumina HiSeq 4000
-        exact_mappings:
-          - OBI:0002049
+        meaning: OBI:0002049
       hiseq_x_ten:
         aliases:
           - Illumina HiSeq X Ten
-        exact_mappings:
-           - OBI:0002129
+        meaning: OBI:0002129
       miniseq:
         aliases:
           - Illumina MiniSeq
-        exact_mappings:
-          - OBI:0003114
+        meaning: OBI:0003114
       nextseq_1000:
         aliases:
           - Illumina NextSeq 1000
-        exact_mappings:
-          - OBI:0003606
+        meaning: OBI:0003606
       miseq:
         aliases:
           - MiSeq
           - Illumina MiSeq
-        exact_mappings:
-          - OBI:0002003
+        meaning: OBI:0002003
       nextseq_500:
         aliases:
           - NextSeq 500
-        exact_mappings:
-          - OBI:0002021
+        meaning: OBI:0002021
       nextseq_550:
         aliases:
           - NextSeq 550
-        exact_mappings:
-          - OBI:0003387
+        meaning: OBI:0003387
       gridion:
          aliases:
            - Oxford Nanopore GridION Mk1
-         exact_mappings:
-           - OBI:0002751
+         meaning: OBI:0002751
       minion:
         aliases:
           - Oxford Nanopore MinION
-        exact_mappings:
-          - OBI:0002750
+        meaning: OBI:0002750
       promethion:
         aliases:
           - Oxford Nanopore PromethION
-        exact_mappings:
-          - OBI:0002752
+        meaning: OBI:0002752
       rs_II:
         aliases:
           - PacBio RS II
-        exact_mappings:
-          - OBI:0002012
+        meaning: OBI:0002012
       sequel:
         aliases:
           - PacBio Sequel
-        exact_mappings:
-          - OBI:0002632
+        meaning: OBI:0002632
       sequel_II:
          aliases:
            - PacBio Sequel II
-         exact_mappings:
-           - OBI:0002633
+         meaning: OBI:0002633
+      revio:
+        aliases: 
+           - PacBio Revio
+           - Revio
 
   InstrumentVendorEnum:
     permissible_values:
@@ -2212,20 +2197,16 @@ enums:
       illumina:
         aliases:
           - Illumina
-        exact_mappings:
-          - BAO:0200000
-          - OBI:0000759
+        meaning: BAO:0200000
       pacbio:
         aliases:
           - PacBio
           - Pacific Biosciences
-        exact_mappings:
-          - OBI:0001856
+        meaning: OBI:0001856
       oxford_nanopore:
         aliases:
           - Oxford Nanopore Technologies
-        exact_mappings:
-          - OBI:0002755
+        meaning: OBI:0002755
 
   StatusEnum:
     permissible_values:


### PR DESCRIPTION
This PR expands on the two enumerations to support sequencing based vendors and models. 

We will need to write migration code to map existing values of `instrument_name` to `vendor` and `model`.