### PR TITLE
1123 add img identifiers to workflow execution subclasses

### DIFF
--- a/src/data/invalid/Database-mags-invalid.yaml
+++ b/src/data/invalid/Database-mags-invalid.yaml
@@ -1,0 +1,120 @@
+#invalid b/c img_identifiers is a list
+mags_set:
+  - id: nmdc:wfmag-99-5MiDJM
+    type: nmdc:MagsAnalysis
+    name: MAGs activiity 1781_86101
+    img_identifiers: 
+      - img.taxon:3300062116
+      - img.taxon:3300062117
+    part_of:
+      - nmdc:wfch-11-ab
+    started_at_time: '2021-01-10T00:00:00+00:00'
+    ended_at_time: '2021-01-10T00:00:00+00:00'
+    execution_resource: NERSC-Cori
+    git_url: https://img.jgi.doe.gov
+    has_input:
+      - nmdc:0a3d00715d01ad7b8f3aee59b674dfe9
+      - nmdc:668d207be5ea844f988fbfb2813564cc
+      - nmdc:b7e9c8d0bffdd13ace6f862a61fa87d2
+    has_output:
+      - nmdc:818f5a47d1371295f9313909ea12eb50
+      - nmdc:e0b7421514f976cb7ad8c343cf3077a9
+      - nmdc:a755bb87aded36aefbd8022506a793c7
+      - nmdc:1346fe25b6ff22180eb3a51204e0b1fc
+    input_contig_num: 169782
+    too_short_contig_num: 159810
+    low_depth_contig_num: 0
+    unbinned_contig_num: 9483
+    binned_contig_num: 489
+    mags_list:
+      - bin_name: bins.1
+        type: nmdc:MagBin
+        number_of_contig: 52
+        completeness: 11.42
+        contamination: 0.21
+        gene_count: 250
+        bin_quality: LQ
+        num_16s: 0
+        num_5s: 1
+        num_23s: 0
+        num_t_rna: 1
+      - bin_name: bins.2
+        type: nmdc:MagBin
+        number_of_contig: 426
+        completeness: 51.25
+        contamination: 10.34
+        gene_count: 2548
+        bin_quality: LQ
+        num_16s: 0
+        num_5s: 1
+        num_23s: 0
+        num_t_rna: 26
+      - bin_name: bins.3
+        type: nmdc:MagBin
+        number_of_contig: 11
+        completeness: 2
+        contamination: 0
+        gene_count: 294
+        bin_quality: LQ
+        num_16s: 0
+        num_5s: 0
+        num_23s: 0
+        num_t_rna: 1
+
+  - id: nmdc:wfmag-99-VOgM5i
+    name: MAGs activiity 1781_86089
+    part_of:
+      - nmdc:wfch-12-ab
+    started_at_time: '2021-01-10T00:00:00+00:00'
+    ended_at_time: '2021-01-10T00:00:00+00:00'
+    type: nmdc:MagsAnalysis
+    execution_resource: NERSC-Cori
+    git_url: https://img.jgi.doe.gov
+    has_input:
+      - nmdc:b78f599c21fb31b00d3f8a3c56daeb88
+      - nmdc:662dc676b0b5a486248357f5b887c18b
+      - nmdc:bc034c7024043ea88b44d0897bb5bece
+    has_output:
+      - nmdc:c24915651cfdfc91f3e6b5bac679c3af
+      - nmdc:e8ec230bfe68a272b34540e7f5ab5b2b
+      - nmdc:474fa29bd39452fa80f5a32e9e6be6f4
+      - nmdc:9800add41d26829494265ba81a100c53
+    input_contig_num: 78376
+    too_short_contig_num: 75364
+    low_depth_contig_num: 0
+    unbinned_contig_num: 2806
+    binned_contig_num: 206
+    mags_list:
+      - bin_name: bins.1
+        type: nmdc:MagBin
+        number_of_contig: 74
+        completeness: 25.86
+        contamination: 0
+        gene_count: 401
+        bin_quality: LQ
+        num_16s: 0
+        num_5s: 0
+        num_23s: 0
+        num_t_rna: 4
+      - bin_name: bins.2
+        type: nmdc:MagBin
+        number_of_contig: 74
+        completeness: 0
+        contamination: 0
+        gene_count: 383
+        bin_quality: LQ
+        num_16s: 0
+        num_5s: 0
+        num_23s: 0
+        num_t_rna: 5
+      - bin_name: bins.3
+        type: nmdc:MagBin
+        number_of_contig: 58
+        completeness: 17.61
+        contamination: 0
+        gene_count: 313
+        bin_quality: LQ
+        num_16s: 0
+        num_5s: 0
+        num_23s: 0
+        num_t_rna: 7

--- a/src/data/valid/Database-mags.yaml
+++ b/src/data/valid/Database-mags.yaml
@@ -2,6 +2,7 @@ mags_set:
   - id: nmdc:wfmag-99-5MiDJM
     type: nmdc:MagsAnalysis
     name: MAGs activiity 1781_86101
+    img_identifiers: img.taxon:3300062116
     part_of:
       - nmdc:wfch-11-ab
     started_at_time: '2021-01-10T00:00:00+00:00'

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -199,11 +199,14 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmgan-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
+      img_identifiers:
+        multivalued: false
 
   MetatranscriptomeAnnotation:
     class_uri: "nmdc:MetatranscriptomeAnnotation"
     is_a: WorkflowExecution
     slots:
+      - img_identifiers
     in_subset:
       - workflow subset
     slot_usage:
@@ -212,6 +215,8 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmtan-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
+      img_identifiers:
+        multivalued: false
 
   MetatranscriptomeAnalysis:
     class_uri: "nmdc:MetatranscriptomeAnalysis"
@@ -250,6 +255,8 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmag-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
+      img_identifiers:
+        multivalued: false
 
 
   MetagenomeSequencing:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -190,6 +190,7 @@ classes:
     description: A workflow execution activity that provides functional and structural annotation of assembled metagenome contigs
     is_a: WorkflowExecution
     slots:
+      - img_identifiers
     in_subset:
       - workflow subset
     slot_usage:
@@ -242,6 +243,7 @@ classes:
       - mags_list
       - too_short_contig_num
       - unbinned_contig_num
+      - img_identifiers
     slot_usage:
       id:
         required: true


### PR DESCRIPTION
PR to add img_identifieres to appropriate WorkflowExecution subclasses.

Migration is not strictly needed as these are additive but there are some projects where we'll want to move the identifiers from class Biosample to the WorkflowExecutions subclasses. We do still need to figure out what to do with IMG datasets that we want to link to but not necessarily host, older IMG records, combined assemblies, etc. For now I've left img_identifiers on Biosample.