### PR TITLE
1736 add associated studies to biosample

### DIFF
--- a/nmdc_schema/test_more_tolerant_schema.py
+++ b/nmdc_schema/test_more_tolerant_schema.py
@@ -6,7 +6,7 @@ from nmdc_schema.nmdc_schema_accepting_legacy_ids import Biosample, ControlledId
 def do_test():
     bs = Biosample(id='xxx',
                    type='nmdc:Biosample',
-                   part_of='gold:Gs0114663',
+                   associated_studies='gold:Gs0114663',
                    env_medium=ControlledIdentifiedTermValue(
                        type='nmdc:ControlledIdentifiedTermValue',
                        term=OntologyClass(

--- a/src/data/invalid/Biosample-incomplete_napa_id.yaml
+++ b/src/data/invalid/Biosample-incomplete_napa_id.yaml
@@ -4,7 +4,7 @@ gold_biosample_identifiers:
 name: Lithgow State Coal Mine Calcium nutrients (early)
 description: Bulk Aqueous phase filtered water
 type: nmdc:Biosample
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Biosample-invalid_fire.yaml
+++ b/src/data/invalid/Biosample-invalid_fire.yaml
@@ -1,7 +1,7 @@
 id: nmdc:bsm-99-dtTMNb
 type: nmdc:Biosample
 fire: like a volcano
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Biosample-minimal-invalid-type.yaml
+++ b/src/data/invalid/Biosample-minimal-invalid-type.yaml
@@ -1,6 +1,6 @@
 id: nmdc:bsm-99-dtTMNb
 type: nmdc:UndefinedClass
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Biosample-minimal-no-id-but-with-type.yaml
+++ b/src/data/invalid/Biosample-minimal-no-id-but-with-type.yaml
@@ -1,5 +1,5 @@
 type: nmdc:Biosample
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Biosample-minimal-no-type.yaml
+++ b/src/data/invalid/Biosample-minimal-no-type.yaml
@@ -1,5 +1,5 @@
 id: nmdc:bsm-99-dtTMNb
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Biosample-non_boolean_embargo.yaml
+++ b/src/data/invalid/Biosample-non_boolean_embargo.yaml
@@ -1,6 +1,6 @@
 id: nmdc:bsm-99-dtTMNb
 type: nmdc:Biosample
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-Biosample-invalid_id.yaml
+++ b/src/data/invalid/Database-Biosample-invalid_id.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:local
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-Biosample-invalid_lat_lon_ranges.yaml
+++ b/src/data/invalid/Database-Biosample-invalid_lat_lon_ranges.yaml
@@ -5,7 +5,7 @@ biosample_set:
       - gold:Gb0101224
     name: Lithgow State Coal Mine Calcium nutrients (early)
     description: Bulk Aqueous phase filtered water
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -51,7 +51,7 @@ biosample_set:
       - gold:Gb0101225
     name: Lithgow State Coal Mine Calcium nutrients Extra
     description: Bulk Aqueous phase filtered water
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -97,7 +97,7 @@ biosample_set:
       - gold:Gb0101226
     name: Lithgow State Coal Mine Calcium nutrients
     description: Bulk Aqueous phase filtered water
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosample_gold_id_list_as_primary_key.yaml
+++ b/src/data/invalid/Database-biosample_gold_id_list_as_primary_key.yaml
@@ -5,7 +5,7 @@ biosample_set:
     name: Lithgow State Coal Mine Calcium nutrients (early)
     description: Bulk Aqueous phase filtered water
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -51,7 +51,7 @@ biosample_set:
       - gold:Gb0101225
     name: Lithgow State Coal Mine Calcium nutrients Extra
     description: Bulk Aqueous phase filtered water
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -97,7 +97,7 @@ biosample_set:
       - gold:Gb0101226
     name: Lithgow State Coal Mine Calcium nutrients
     description: Bulk Aqueous phase filtered water
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosample_undeclared_slot.yaml
+++ b/src/data/invalid/Database-biosample_undeclared_slot.yaml
@@ -6,7 +6,7 @@ biosample_set:
       - gold:Gb0101224
     name: Lithgow State Coal Mine Calcium nutrients (early)
     description: Bulk Aqueous phase filtered water
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -52,7 +52,7 @@ biosample_set:
     name: Lithgow State Coal Mine Calcium nutrients Extra
     description: Bulk Aqueous phase filtered water
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -99,7 +99,7 @@ biosample_set:
     name: Lithgow State Coal Mine Calcium nutrients
     description: Bulk Aqueous phase filtered water
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-dna-in-bucket.yaml
+++ b/src/data/invalid/Database-biosamples-dna-in-bucket.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-dna-in-plate-invalid-well-val.yaml
+++ b/src/data/invalid/Database-biosamples-dna-in-plate-invalid-well-val.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-dna-in-plate-no-well-val.yaml
+++ b/src/data/invalid/Database-biosamples-dna-in-plate-no-well-val.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-dna-in-tube-with-well-value.yaml
+++ b/src/data/invalid/Database-biosamples-dna-in-tube-with-well-value.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-high-rna_volume.yaml
+++ b/src/data/invalid/Database-biosamples-high-rna_volume.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-lat_lon-with-GLV-missing-latitude.yaml
+++ b/src/data/invalid/Database-biosamples-lat_lon-with-GLV-missing-latitude.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-lat_lon-with-GLV-missing-longitude.yaml
+++ b/src/data/invalid/Database-biosamples-lat_lon-with-GLV-missing-longitude.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-rna-in-bucket.yaml
+++ b/src/data/invalid/Database-biosamples-rna-in-bucket.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-rna-in-plate-invalid-well-val.yaml
+++ b/src/data/invalid/Database-biosamples-rna-in-plate-invalid-well-val.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-rna-in-plate-no-well-val.yaml
+++ b/src/data/invalid/Database-biosamples-rna-in-plate-no-well-val.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-biosamples-rna-in-tube-with-well-value.yaml
+++ b/src/data/invalid/Database-biosamples-rna-in-tube-with-well-value.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/invalid/Database-data-generation-instrument_name-invalid.yaml
+++ b/src/data/invalid/Database-data-generation-instrument_name-invalid.yaml
@@ -13,7 +13,7 @@ data_generation_set:
       - nmdc:dobj-00-9n9n9n
     ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
       carbon transformations - Permafrost 712P3D
-    part_of:
+    associated_studies:
       - nmdc:dgns-00-555xxx
     processing_institution: JGI
     type: nmdc:NucleotideSequencing

--- a/src/data/invalid/Database-data-generation-undefined-omics-processing.yaml
+++ b/src/data/invalid/Database-data-generation-undefined-omics-processing.yaml
@@ -49,7 +49,7 @@ data_generation_set:
       - nmdc:dobj-00-thx1198
     ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
       carbon transformations - Permafrost 712S3S
-    part_of:
+    associated_studies:
       - nmdc:dgns-00-555xxx
     processing_institution: JGI
     omics_type: THIS SLOT IS NOT AVAILABLE FOR THIS CLAS ANYMORE

--- a/src/data/valid/Biosample-embargoed.yaml
+++ b/src/data/valid/Biosample-embargoed.yaml
@@ -1,6 +1,6 @@
 id: nmdc:bsm-99-dtTMNb
 type: nmdc:Biosample
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Biosample-minimal.yaml
+++ b/src/data/valid/Biosample-minimal.yaml
@@ -1,6 +1,6 @@
 id: nmdc:bsm-99-dtTMNb
 type: nmdc:Biosample
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Biosample-soil_horizon.yaml
+++ b/src/data/valid/Biosample-soil_horizon.yaml
@@ -1,6 +1,6 @@
 id: nmdc:bsm-99-dtTMNb
 type: nmdc:Biosample
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Biosample-with-fire.yaml
+++ b/src/data/valid/Biosample-with-fire.yaml
@@ -1,7 +1,7 @@
 id: nmdc:bsm-99-dtTMNb
 type: nmdc:Biosample
 fire: 1871-10-01 to 1871-10-31
-part_of:
+associated_studies:
   - nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosample-exhasutive.yaml
+++ b/src/data/valid/Database-biosample-exhasutive.yaml
@@ -7,7 +7,7 @@ biosample_set:
     description: unconstrained text
     alternative_identifiers:
       - generic:abc123
-    part_of:
+    associated_studies:
       - nmdc:sty-00-987654
       - nmdc:sty-00-qwerty
     env_broad_scale:

--- a/src/data/valid/Database-biosample_set_low-but-acceptable-rna_volume.yaml
+++ b/src/data/valid/Database-biosample_set_low-but-acceptable-rna_volume.yaml
@@ -1,6 +1,6 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-1.yaml
+++ b/src/data/valid/Database-biosamples-1.yaml
@@ -5,7 +5,7 @@ biosample_set:
     name: Lithgow State Coal Mine Calcium nutrients (early)
     description: Bulk Aqueous phase filtered water
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -61,7 +61,7 @@ biosample_set:
       - SIP
     description: Bulk Aqueous phase filtered water
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -114,7 +114,7 @@ biosample_set:
     name: Lithgow State Coal Mine Calcium nutrients Extra
     description: Bulk Aqueous phase filtered water
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -167,7 +167,7 @@ biosample_set:
     name: Lithgow State Coal Mine Calcium nutrients
     description: Bulk Aqueous phase filtered water
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-dna-in-plate-valid-well-val.yaml
+++ b/src/data/valid/Database-biosamples-dna-in-plate-valid-well-val.yaml
@@ -1,6 +1,6 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-dna-in-tube.yaml
+++ b/src/data/valid/Database-biosamples-dna-in-tube.yaml
@@ -1,6 +1,6 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-minimal.yaml
+++ b/src/data/valid/Database-biosamples-minimal.yaml
@@ -1,6 +1,6 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-rna-in-plate-valid-well-val.yaml
+++ b/src/data/valid/Database-biosamples-rna-in-plate-valid-well-val.yaml
@@ -1,6 +1,6 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-rna-in-tube.yaml
+++ b/src/data/valid/Database-biosamples-rna-in-tube.yaml
@@ -1,6 +1,6 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-sites.yaml
+++ b/src/data/valid/Database-biosamples-sites.yaml
@@ -37,7 +37,7 @@ biosample_set:
     collected_from: nmdc:frsite-99-SPreao
     gold_biosample_identifiers:
       - gold:Gb0291692
-    part_of:
+    associated_studies:
       - nmdc:sty-99-U21mUX
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -66,7 +66,7 @@ biosample_set:
     collected_from: nmdc:frsite-99-SPreao
     gold_biosample_identifiers:
       - gold:Gb0291582
-    part_of:
+    associated_studies:
       - nmdc:sty-99-U21mUX
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -95,7 +95,7 @@ biosample_set:
     collected_from: nmdc:frsite-99-h2mYFG
     gold_biosample_identifiers:
       - gold:Gb0305834
-    part_of:
+    associated_studies:
       - nmdc:sty-99-U21mUX
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -124,7 +124,7 @@ biosample_set:
     collected_from: nmdc:frsite-99-h2mYFG
     gold_biosample_identifiers:
       - gold:Gb0291693
-    part_of:
+    associated_studies:
       - nmdc:sty-99-U21mUX
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -153,7 +153,7 @@ biosample_set:
     collected_from: nmdc:frsite-99-h2mYFG
     gold_biosample_identifiers:
       - gold:Gb0291583
-    part_of:
+    associated_studies:
       - nmdc:sty-99-U21mUX
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-biosamples-sites.yaml
+++ b/src/data/valid/Database-biosamples-sites.yaml
@@ -8,7 +8,7 @@ biosample_set:
     collected_from: nmdc:frsite-99-SPreao
     gold_biosample_identifiers:
       - gold:Gb0305833
-    part_of:
+    associated_studies:
       - nmdc:sty-99-U21mUX
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-multiple-paths.yaml
+++ b/src/data/valid/Database-multiple-paths.yaml
@@ -1,7 +1,7 @@
 biosample_set:
   - id: nmdc:bsm-99-dtTMNb
     name: real biosample from the field
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -24,7 +24,7 @@ biosample_set:
     type: nmdc:Biosample
   - id: nmdc:bsm-99-XYZ
     name: one DNA library, like an analytical sample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-neon-story.yaml
+++ b/src/data/valid/Database-neon-story.yaml
@@ -58,7 +58,7 @@ library_preparation_set:
 
 biosample_set:
   - id: nmdc:bsm-99-abcdef1
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -80,7 +80,7 @@ biosample_set:
         id: ENVO:00005792
     type: nmdc:Biosample
   - id: nmdc:bsm-99-abcdef2
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -102,7 +102,7 @@ biosample_set:
         id: ENVO:00005792
     type: nmdc:Biosample
   - id: nmdc:bsm-99-abcdef3
-    part_of:
+    associated_studies:
       - nmdc:sty-00-abc123
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-neon_Biosample_to_DataObject_NEON.yaml
+++ b/src/data/valid/Database-neon_Biosample_to_DataObject_NEON.yaml
@@ -33,7 +33,7 @@ extraction_set:
 biosample_set:
   - id: nmdc:bsm-99-abcdef1
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-11-34xj1150
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -55,7 +55,7 @@ biosample_set:
         id: ENVO:00005792
   - id: nmdc:bsm-99-abcdef2
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-11-34xj1150
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue
@@ -77,7 +77,7 @@ biosample_set:
         id: ENVO:00005792
   - id: nmdc:bsm-99-abcdef3
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-11-34xj1150
     env_broad_scale:
       type: nmdc:ControlledIdentifiedTermValue

--- a/src/data/valid/Database-nmdc-example.yaml
+++ b/src/data/valid/Database-nmdc-example.yaml
@@ -136,7 +136,7 @@ biosample_set:
     name: Permafrost microbial communities from Stordalen Mire, Sweden - 611E1M metaG
     description: Permafrost microbial communities from Stordalen Mire, Sweden
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     #    collection_date:
     #      has_raw_value: '2011-06-15'
@@ -188,7 +188,7 @@ biosample_set:
       at 10C with heavy water. Sample is from a control plot at ambient soil temperature,
       organic horizon - top 4cm of soil
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     #    collection_date:
     #      has_raw_value: '2017-05-24'
@@ -240,7 +240,7 @@ biosample_set:
     description: Rhizosphere microbial communities from Carex aquatilis grown in submerged
       peat from a thermokarst bog, University of Washington, Seatle, WA, United States
     type: nmdc:Biosample
-    part_of:
+    associated_studies:
       - nmdc:sty-00-8675309
     #    collection_date:
     #      has_raw_value: '2018-01-29'

--- a/src/data/valid/NucleotideSequencing-2.yaml
+++ b/src/data/valid/NucleotideSequencing-2.yaml
@@ -17,3 +17,5 @@ ncbi_project_name: Thawing permafrost microbial communities from the Arctic, stu
 part_of:
   - nmdc:omprc-00-555xxx
 processing_institution: JGI
+associated_studies:
+  - nmdc:sty-00-xxx

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -543,6 +543,7 @@ classes:
         Samples are associated with checklists, which define the fields used to annotate
         the samples. Samples are always associated with a taxon.
     slots:
+      - associated_studies
       - biosample_categories
       - collected_from
       - embargoed
@@ -550,7 +551,6 @@ classes:
       - host_taxid
       - img_identifiers
       - neon_biosample_identifiers
-      - part_of
       - samp_name
 
       ## external IDs, alternate IDs
@@ -1226,10 +1226,6 @@ classes:
         required: true
       env_medium:
         required: true
-      part_of:
-        required: true
-        range: Study
-        pattern: "^nmdc:sty-[0-9][a-z]{0,6}[0-9]-[A-Za-z0-9]{1,}(\\.[A-Za-z0-9]{1,})*(_[A-Za-z0-9_\\.-]+)?$" # better applied as a structured_pattern, but even that might get out of sync from the asserted Study structured_pattern
 
       fire:
         comments:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2853,6 +2853,7 @@ slots:
     range: Study
     multivalued: true
     pattern: "^nmdc:sty-[0-9][a-z]{0,6}[0-9]-[A-Za-z0-9]{1,}(\\.[A-Za-z0-9]{1,})*(_[A-Za-z0-9_\\.-]+)?$"
+    required: true
 
   data_category:
     domain: DataObject

--- a/tests/test_biosample_instantiation.py
+++ b/tests/test_biosample_instantiation.py
@@ -13,7 +13,7 @@ class TestBiosampleInstantiation(unittest.TestCase):
 
         bs = Biosample(
             id="bs:1",
-            part_of=[
+            associated_studies=[
                 "study:1",
                 "study:2",
             ],
@@ -48,7 +48,7 @@ class TestBiosampleInstantiation(unittest.TestCase):
                 env_local_scale=ControlledTermValue(),
                 env_medium=ControlledTermValue(),
                 id="x",
-                part_of="x",
+                associated_studies="x",
                 type="nmdc:Biosample",
             )
 


### PR DESCRIPTION
This PR models the `Biosample` class the same as the we did for the `DataGeneration` class and parthood. It removes the `part_of` slot from `Biosample` and instead uses the `associated_studies` slot we created to link studies to their biosamples. 

For issue: https://github.com/microbiomedata/nmdc-schema/issues/1736