### PR TITLE
collection name change migrator and test all currently written migrators

### DIFF
--- a/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
@@ -27,4 +27,8 @@ class Migrator(MigratorBase):
             }
 
         for current_collection_name, new_collection_name in old_to_new_names.items():
-            self.adapter.rename_collection(current_name=current_collection_name, new_name=new_collection_name)
+            try:
+                self.adapter.rename_collection(current_name=current_collection_name, new_name=new_collection_name)
+            except KeyError:
+                print(f"Error: Collection '{current_collection_name}' not found in the adapter.")
+

--- a/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
@@ -3,7 +3,7 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 
 class Migrator(MigratorBase):
     """
-    Migrates data between from X to PR2 and PR24, namely renames all renamed collections.
+    Migrates data from X to PR2 and PR24, namely renames all renamed collections.
     """
     _from_version = "X"
     _to_version = "PR2_and_PR24"

--- a/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
@@ -3,7 +3,7 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 
 class Migrator(MigratorBase):
     """
-    Migrates data between from X to PR2 and PR24
+    Migrates data between from X to PR2 and PR24, namely renames all renamed collections.
     """
     _from_version = "X"
     _to_version = "PR2_and_PR24"
@@ -13,7 +13,7 @@ class Migrator(MigratorBase):
         Migrates the database from conforming to the original schema, to conforming to the new schema.
         """
 
-        agenda = {
+        old_to_new_names = {
             "omics_processing_set": "data_generation_set",
             "mags_activity_set": "mags_set",
             "metabolomics_analysis_activity_set": "metabolomics_analysis_set",
@@ -26,5 +26,5 @@ class Migrator(MigratorBase):
             "read_qc_analysis_activity_set": "read_qc_analysis_set"
             }
 
-        for current_collection_name, new_collection_name in agenda.items():
+        for current_collection_name, new_collection_name in old_to_new_names.items():
             self.adapter.rename_collection(current_name=current_collection_name, new_name=new_collection_name)

--- a/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
@@ -1,0 +1,30 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    """
+    Migrates data between from X to PR2 and PR24
+    """
+    _from_version = "X"
+    _to_version = "PR2_and_PR24"
+
+    def upgrade(self):
+        r"""
+        Migrates the database from conforming to the original schema, to conforming to the new schema.
+        """
+
+        agenda = {
+            "omics_processing_set": "data_generation_set",
+            "mags_activity_set": "mags_set",
+            "metabolomics_analysis_activity_set": "metabolomics_analysis_set",
+            "metagenome_annotation_activity_set": "metagenome_annotation_set",
+            "metagenome_sequencing_activity_set": "metagenome_sequencing_set",
+            "metaproteomics_analysis_activity_set": "metaproteomics_analysis_set",
+            "metatranscriptome_activity_set": "metatranscriptome_analysis_set",
+            "nom_analysis_activity_set": "nom_analysis_set",
+            "read_based_taxonomy_analysis_activity_set": "read_based_taxonomy_analysis_set",
+            "read_qc_analysis_activity_set": "read_qc_analysis_set"
+            }
+
+        for current_collection_name, new_collection_name in agenda.items():
+            self.adapter.rename_collection(current_name=current_collection_name, new_name=new_collection_name)

--- a/project.Makefile
+++ b/project.Makefile
@@ -175,7 +175,6 @@ local/mongo_as_unvalidated_nmdc_database.yaml:
 		--page-size 200000 \
 		--schema-file src/schema/nmdc.yaml \
 		--selected-collections activity_set \
-		--selected-collections metaproteomics_analysis_activity_set \
 		--selected-collections biosample_set \
 		--selected-collections collecting_biosamples_from_site_set \
 		--selected-collections data_object_set \
@@ -199,18 +198,12 @@ local/mongo_as_unvalidated_nmdc_database.yaml:
 		--selected-collections read_based_taxonomy_analysis_activity_set \
 		--selected-collections read_qc_analysis_activity_set \
 		--selected-collections study_set \
-		--selected-collections extraction_set \
 		--skip-collection-check
 
 local/mongo_as_nmdc_database_rdf_safe.yaml: nmdc_schema/nmdc_schema_accepting_legacy_ids.yaml local/mongo_as_unvalidated_nmdc_database.yaml
 	date # 449.56 seconds on 2023-08-30 without functional_annotation_agg or metaproteomics_analysis_activity_set
 	time $(RUN) migration-recursion \
-		--migrator-name migrator_from_X_to_PR23 \
-		--migrator-name migrator_from_X_to_PR4 \
-		--migrator-name migrator_from_X_to_PR53 \
-		--migrator-name migrator_from_X_to_PR21 \
-		--migrator-name migrator_from_X_to_PR2_and_PR24 \
-		--migrator-name migrator_from_X_to_PR10 \
+		--migrator-name migrator_from_9_3_to_10_0 \
 		--schema-path $(word 1,$^) \
 		--input-path $(word 2,$^) \
 		--salvage-prefix generic \

--- a/project.Makefile
+++ b/project.Makefile
@@ -175,6 +175,7 @@ local/mongo_as_unvalidated_nmdc_database.yaml:
 		--page-size 200000 \
 		--schema-file src/schema/nmdc.yaml \
 		--selected-collections activity_set \
+		--selected-collections metaproteomics_analysis_activity_set \
 		--selected-collections biosample_set \
 		--selected-collections collecting_biosamples_from_site_set \
 		--selected-collections data_object_set \
@@ -198,12 +199,18 @@ local/mongo_as_unvalidated_nmdc_database.yaml:
 		--selected-collections read_based_taxonomy_analysis_activity_set \
 		--selected-collections read_qc_analysis_activity_set \
 		--selected-collections study_set \
+		--selected-collections extraction_set \
 		--skip-collection-check
 
 local/mongo_as_nmdc_database_rdf_safe.yaml: nmdc_schema/nmdc_schema_accepting_legacy_ids.yaml local/mongo_as_unvalidated_nmdc_database.yaml
 	date # 449.56 seconds on 2023-08-30 without functional_annotation_agg or metaproteomics_analysis_activity_set
 	time $(RUN) migration-recursion \
-		--migrator-name migrator_from_9_3_to_10_0 \
+		--migrator-name migrator_from_X_to_PR23 \
+		--migrator-name migrator_from_X_to_PR4 \
+		--migrator-name migrator_from_X_to_PR53 \
+		--migrator-name migrator_from_X_to_PR21 \
+		--migrator-name migrator_from_X_to_PR2_and_PR24 \
+		--migrator-name migrator_from_X_to_PR10 \
 		--schema-path $(word 1,$^) \
 		--input-path $(word 2,$^) \
 		--salvage-prefix generic \

--- a/project.Makefile
+++ b/project.Makefile
@@ -203,7 +203,7 @@ local/mongo_as_unvalidated_nmdc_database.yaml:
 local/mongo_as_nmdc_database_rdf_safe.yaml: nmdc_schema/nmdc_schema_accepting_legacy_ids.yaml local/mongo_as_unvalidated_nmdc_database.yaml
 	date # 449.56 seconds on 2023-08-30 without functional_annotation_agg or metaproteomics_analysis_activity_set
 	time $(RUN) migration-recursion \
-		--migrator-name migrator_from_9_3_to_10_0 \
+		--migrator-name migrator_from_X_to_PR2_and_PR24 \
 		--schema-path $(word 1,$^) \
 		--input-path $(word 2,$^) \
 		--salvage-prefix generic \


### PR DESCRIPTION
This PR creates a migration for changing the mongodb collection names that were changed during the refactoring. Namely `omics_processing_set` to `data_generation_set` and all of the workflow execution sets to remove `activity` from their name. It solves the migration for two PRs: 

https://github.com/microbiomedata/berkeley-schema-fy24/pull/2

https://github.com/microbiomedata/berkeley-schema-fy24/pull/24

