### PR TITLE
moved `range` of slot `compound` from global definition into a `slot_usage` on `SolutionComponent`

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -308,6 +308,12 @@ classes:
       - compound
       - concentration
       - type
+    slot_usage:
+      compound:
+        any_of:
+        - range: CompoundEnum
+        - range: ProteolyticEnzymeEnum
+
 
   Solution:
     class_uri: nmdc:Solution
@@ -3734,9 +3740,6 @@ slots:
     #list example
   compound:
     domain: SolutionComponent
-    any_of:
-      - range: CompoundEnum
-      - range: ProteolyticEnzymeEnum
     description: A substance that consists of more than one atom or ion. Includes solvents and solutes. Can be combined into solutions.
     required: true
   ordered_mobile_phases:


### PR DESCRIPTION
Moved the ` any_of:` usage from where we define the range of `Slot: compound` to the `Class:SolutionComponent` definition as a `slot_usage`. As per @sujaypatil96 suggestion in https://github.com/microbiomedata/nmdc-schema/issues/1666#issuecomment-1915214482 

But it had no change on the `testdoc` generation. The range of `Slot: compound` still comes up as a string instead of the Enum's we require.