### PR TITLE
Fix `was_informed_by` range in global definition vs. slot usage definition

### DIFF
--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -43,7 +43,7 @@ slots:
 
   was_informed_by:
     domain: WorkflowExecution
-    range: WorkflowExecution
+    range: DataGeneration
     mappings:
       - prov:wasInformedBy
 

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -47,7 +47,6 @@ classes:
         description: >-
           A Workflow Chain instance was informed by the data and metadata of a of a 
             Data Generation instance
-        range: DataGeneration
         comments: >-
           The value of this slot is a reference to a Data Generation 
           instance that informed the Workflow Chain instance with its


### PR DESCRIPTION
Regarding this issue: https://github.com/microbiomedata/nmdc-schema/issues/1830

This PR fixes the `range` of the `was_informed_by` slot to be `DataGeneration` in the global slot definition. And removes the `range` from the slot usage in the `WorkflowChain` class. These previously mismatched, with the global definition having a `range` of `WorkflowExecution` and the slot usage having a definition of `WorkflowChain`.