### PR TITLE
add permissible values for non-specific novaseq and hiseq to insturment enum

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1981,11 +1981,16 @@ enums:
       vortex_genie_2:
         aliases:
           - VortexGenie2
-      novaseq_6000:
+      novaseq:
         aliases:
           - NovaSeq
+      novaseq_6000:
+        aliases:
           - NovaSeq 6000
         meaning: OBI:0002630
+      hiseq:
+        aliases:
+          - Illumina HiSeq
       hiseq_1000:
         aliases:
           - Illumina HiSeq 1000


### PR DESCRIPTION
When doing the instrument migration, @aclum pointed out that the places NMDC is pulling from don't always have the model serial number so we need to add 'novaseq' and 'hiseq' to the InstrumentModelEnum.

Addresses issue https://github.com/microbiomedata/nmdc-schema/issues/1855