### PR TITLE
Use of `any_of` construct on slot ranges was not reflecting on class doc pages

### DIFF
--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -8,6 +8,19 @@
     {%- endif -%}
 {%- endif -%}
 
+{% macro compute_range(slot) -%}
+    {%- if slot.any_of or slot.exactly_one_of -%}
+        {%- for subslot_range in schemaview.slot_range_as_union(slot) -%}
+            {{ gen.link(subslot_range) }}
+            {%- if not loop.last -%}
+                &nbsp;or&nbsp;<br />
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ gen.link(slot.range) }}
+    {%- endif -%}
+{% endmacro %}
+
 # Class: {{ title }}
 
 {%- if header -%}
@@ -52,12 +65,12 @@ URI: {{ gen.uri_link(element) }}
 | ---  | --- | --- | --- |
 {% if gen.get_direct_slots(element)|length > 0 %}
 {%- for slot in gen.get_direct_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | direct |
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | direct |
 {% endfor -%}
 {% endif -%}
 {% if gen.get_indirect_slots(element)|length > 0 %}
 {%- for slot in gen.get_indirect_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
 {% endfor -%}
 {% endif %}
 


### PR DESCRIPTION
Consider the class documentation page for `MaterialProcessing`: https://microbiomedata.github.io/berkeley-schema-fy24/MaterialProcessing/

In the _Slots_ table: https://microbiomedata.github.io/berkeley-schema-fy24/MaterialProcessing/#slots in range for the `has_input` slot does not capture what's in the model, i.e., the range modification.

```bash
  has_input:
    name: has_input
    domain_of:
    - PlaceholderClass
    - PlannedProcess
    any_of:
    - range: Biosample
    - range: ProcessedSample
```

The base linkml class documentation pages jinja template here: https://github.com/linkml/linkml/blob/main/linkml/generators/docgen/class.md.jinja2 does actually have the logic to capture/reflect this, but since we are maintaining a custom jinja template for our project, we need to make sure this template has all the latest and greatest features from the base templates.