### PR TITLE
Update MetaboliteQuantification to MetaboliteIdentification

### DIFF
--- a/nmdc_schema/migrators/migrator_from_X_to_PR129.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR129.py
@@ -23,8 +23,8 @@ class Migrator(MigratorBase):
         and metabolite_quantified to metabolite_identified.
 
         >>> m = Migrator()  
-        >>> m.change_metab_slot_names({'id': 123, 'has_metabolite_quantifications': {'metabolite_quantified': 'chebi:16997'}})  
-        {'id': 123, 'has_metabolite_identifications': {'metabolite_identified': 'chebi:16997'}}
+        >>> m.change_metab_slot_names({'id': 123, 'has_metabolite_quantifications': [{'metabolite_quantified': 'chebi:16997'}]})  
+        {'id': 123, 'has_metabolite_identifications': [{'metabolite_identified': 'chebi:16997'}]}
         """
 
         if "has_metabolite_quantifications" in metab_doc:

--- a/nmdc_schema/migrators/migrator_from_X_to_PR129.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR129.py
@@ -1,0 +1,35 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    """
+    Migrates data from X to PR129, namely changes the slot names has_metabolite_quantifications to has_metabolite_identifications
+    and metabolite_quantified to metabolite_identified.
+    """
+
+    _from_version = "X"
+    _to_version = "PR129"
+
+    def upgrade(self):
+        r"""
+        Migrates the database from conforming to the original schema, to conforming to the new schema.
+        """
+
+        self.adapter.process_each_document(collection_name="metabolomics_analysis_activity_set", pipeline=[self.change_metab_slot_names])
+
+    def change_metab_slot_names(self, metab_doc: dict) -> dict:
+        r"""
+        Changes the slot names has_metabolite_quantifications to has_metabolite_identifications
+        and metabolite_quantified to metabolite_identified.
+
+        >>> m = Migrator()  
+        >>> m.change_metab_slot_names({'id': 123, 'has_metabolite_quantifications': {'metabolite_quantified': 'chebi:16997'}})  
+        {'id': 123, 'has_metabolite_identifications': {'metabolite_identified': 'chebi:16997'}}
+        """
+
+        if "has_metabolite_quantifications" in metab_doc:
+            metab_doc["has_metabolite_identifications"] = metab_doc.pop("has_metabolite_quantifications")
+            for metabolite in metab_doc["has_metabolite_identifications"]:
+                metabolite["metabolite_identified"] = metabolite.pop("metabolite_quantified")
+           
+        return metab_doc

--- a/src/data/invalid/MetabolomicsAnalysis-metab_quantified.yaml
+++ b/src/data/invalid/MetabolomicsAnalysis-metab_quantified.yaml
@@ -12,10 +12,9 @@ has_input:
 has_output:
   - nmdc:o1
   - nmdc:o2
-has_metabolite_identifications:
+has_metabolite_quantifications:
   - alternative_identifiers:
     - kegg:C00583
     - cas:57-55-6
     highest_similarity_score: 0.9534156546099186
-    metabolite_identified: chebi:16997
-
+    metabolite_quantified: chebi:16997

--- a/src/data/invalid/MetabolomicsAnalysis-metab_quantified.yaml
+++ b/src/data/invalid/MetabolomicsAnalysis-metab_quantified.yaml
@@ -18,3 +18,4 @@ has_metabolite_quantifications:
     - cas:57-55-6
     highest_similarity_score: 0.9534156546099186
     metabolite_quantified: chebi:16997
+    type: nmdc:MetaboliteQuantification

--- a/src/data/valid/MetabolomicsAnalysis-1.yaml
+++ b/src/data/valid/MetabolomicsAnalysis-1.yaml
@@ -18,4 +18,5 @@ has_metabolite_identifications:
     - cas:57-55-6
     highest_similarity_score: 0.9534156546099186
     metabolite_identified: chebi:16997
+    type: nmdc:MetaboliteIdentification
 

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1270,13 +1270,13 @@ classes:
       - total_bases
       - type
 
-  MetaboliteQuantification:
-    class_uri: "nmdc:MetaboliteQuantification"
+  MetaboliteIdentification:
+    class_uri: "nmdc:MetaboliteIdentification"
     description: This is used to link a metabolomics analysis workflow to a specific metabolite
     slots:
       - alternative_identifiers
       - highest_similarity_score
-      - metabolite_quantified
+      - metabolite_identified
       - type
 
   PeptideQuantification:
@@ -1663,7 +1663,7 @@ slots:
       - Yuri to fill in description
     range: float
 
-  metabolite_quantified:
+  metabolite_identified:
     description: the specific metabolite identifier
     range: ChemicalEntity
 

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -219,7 +219,7 @@ classes:
       - workflow subset
     slots:
       - has_calibration
-      - has_metabolite_quantifications
+      - has_metabolite_identifications
     slot_usage:
       id:
         required: true
@@ -497,7 +497,7 @@ slots:
       occurred. The commented out portion of the slot definition above will be implemented. See PR #29 in Berkeley
       schema.
 
-  has_metabolite_quantifications:
+  has_metabolite_identifications:
     domain: MetabolomicsAnalysis
-    range: MetaboliteQuantification
+    range: MetaboliteIdentification
     multivalued: true


### PR DESCRIPTION
Issue #1914 

Changes the name of the `MetaboliteQuantification` class to `MetaboliteIdentification` and the slot `has_metabolite_quantifications` to `has_metabolite_identifications` and the slot `metabolite_quantified` to `metabolite_identified`.

Migration included in this PR. Migration needs to come BEFORE collections names are changed as the migration refers to the old collection name (`metabolomics_analysis_activity_set`). 