### PR TITLE
Add `sampled_portion` slot

### DIFF
--- a/src/data/valid/SubSamplingProcess-minimal.yaml
+++ b/src/data/valid/SubSamplingProcess-minimal.yaml
@@ -21,3 +21,4 @@ mass:
   has_unit: g
 has_output:
   - nmdc:procsm-11-05g48p90
+sample_portion: "supernatant"

--- a/src/data/valid/SubSamplingProcess-minimal.yaml
+++ b/src/data/valid/SubSamplingProcess-minimal.yaml
@@ -21,4 +21,5 @@ mass:
   has_unit: g
 has_output:
   - nmdc:procsm-11-05g48p90
-sample_portion: "supernatant"
+sample_portion: 
+  - supernatant

--- a/src/data/valid/SubSamplingProcess-minimal.yaml
+++ b/src/data/valid/SubSamplingProcess-minimal.yaml
@@ -21,5 +21,5 @@ mass:
   has_unit: g
 has_output:
   - nmdc:procsm-11-05g48p90
-sample_portion: 
+sampled_portion: 
   - supernatant

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -652,7 +652,19 @@ enums:
       solid_phase_extraction:
         aliases:
           - SPE
-
+  
+  SamplePortionEnum:
+    permissible_values:
+      supernatant:
+        aliases:
+          - top_layer
+      pellet:
+        aliases:
+          - bottom_layer
+      organic_layer:
+      aqueous_layer:
+      
+      
 slots:
 
   polarity_mode:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -347,6 +347,7 @@ classes:
       - temperature
       - volume
       - mass
+      - sample_portion
     slot_usage:
       id:
         required: true
@@ -1069,4 +1070,7 @@ slots:
 #    description: A substance within a formulation that enhances the solubility of another substance.
 #    exact_mappings:
 #      - NCIT:C176640
-
+  sample_portion:
+    domain: SubSamplingProcess
+    range: SamplePortionEnum
+    description: The portion of the sample that is taken for downstream activity.

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -652,15 +652,6 @@ enums:
       solid_phase_extraction:
         aliases:
           - SPE
-  
-  SamplePortionEnum:
-    permissible_values:
-      supernatant:
-        aliases:
-          - top_layer
-      organic_layer:
-      aqueous_layer:
-      non_polar_layer:
 
 slots:
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -347,7 +347,7 @@ classes:
       - temperature
       - volume
       - mass
-      - sample_portion
+      - sampled_portion
     slot_usage:
       id:
         required: true
@@ -1083,7 +1083,7 @@ slots:
 #    description: A substance within a formulation that enhances the solubility of another substance.
 #    exact_mappings:
 #      - NCIT:C176640
-  sample_portion:
+  sampled_portion:
     domain: SubSamplingProcess
     range: SamplePortionEnum
     multivalued: true

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -652,6 +652,15 @@ enums:
       solid_phase_extraction:
         aliases:
           - SPE
+  
+  SamplePortionEnum:
+    permissible_values:
+      supernatant:
+        aliases:
+          - top_layer
+      organic_layer:
+      aqueous_layer:
+      non_polar_layer:
 
 slots:
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -663,6 +663,7 @@ enums:
           - bottom_layer
       organic_layer:
       aqueous_layer:
+      non_polar_layer:
 
       
 slots:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -663,7 +663,7 @@ enums:
           - bottom_layer
       organic_layer:
       aqueous_layer:
-      
+
       
 slots:
 
@@ -1085,4 +1085,5 @@ slots:
   sample_portion:
     domain: SubSamplingProcess
     range: SamplePortionEnum
+    multivalued: true
     description: The portion of the sample that is taken for downstream activity.


### PR DESCRIPTION
Adding so we are able to capture what portion of the sample went to analysis. Current use case is for derivatization prep, sometimes a portion of the non-polar layer is included. 