### PR TITLE
add `configuration_data_objects` slot

### DIFF
--- a/src/data/valid/MetabolomicsAnalysis-1.yaml
+++ b/src/data/valid/MetabolomicsAnalysis-1.yaml
@@ -19,7 +19,7 @@ has_metabolite_identifications:
     highest_similarity_score: 0.9534156546099186
     metabolite_identified: chebi:16997
     type: nmdc:MetaboliteIdentification
-workflow_configuration_objects:
+configuration_data_objects:
   - nmdc:dobj-99-izwYW6
   - nmdc:dobj-78-ebzPH6
 

--- a/src/data/valid/MetabolomicsAnalysis-1.yaml
+++ b/src/data/valid/MetabolomicsAnalysis-1.yaml
@@ -19,4 +19,7 @@ has_metabolite_identifications:
     highest_similarity_score: 0.9534156546099186
     metabolite_identified: chebi:16997
     type: nmdc:MetaboliteIdentification
+workflow_configuration_objects:
+  - nmdc:dobj-99-izwYW6
+  - nmdc:dobj-78-ebzPH6
 

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -376,7 +376,7 @@ classes:
       - part_of
       - started_at_time
       - version
-      - workflow_configuration_objects
+      - configuration_data_objects
     rules:
       - title: qc_status_pass_has_output_required
         description: >-
@@ -425,7 +425,7 @@ classes:
           syntax: "{id_nmdc_prefix}:wf-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
 slots:
-  workflow_configuration_objects:
+  configuration_data_objects:
     description: >-
       Data object(s) that stores settings that are specific to a particular software.
     range: DataObject

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -427,7 +427,7 @@ classes:
 slots:
   configuration_data_objects:
     description: >-
-      Data object(s) that stores settings that are specific to a particular software.
+      Data object(s) that stores settings that are specific to a particular process or software.
     range: DataObject
     multivalued: true
     examples:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -376,6 +376,7 @@ classes:
       - part_of
       - started_at_time
       - version
+      - workflow_configuration_objects
     rules:
       - title: qc_status_pass_has_output_required
         description: >-
@@ -424,6 +425,15 @@ classes:
           syntax: "{id_nmdc_prefix}:wf-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
 slots:
+  workflow_configuration_objects:
+    description: >-
+      Data object(s) that stores settings that are specific to a particular software.
+    range: DataObject
+    multivalued: true
+    examples:
+      value: 
+        - nmdc:dobj-99-izwYW6
+        - nmdc:dobj-78-ebzPH6
   associated_studies:
     description: The study associated with a resource.
     range: Study


### PR DESCRIPTION
issue https://github.com/microbiomedata/nmdc-schema/issues/1912

Adds a `configuration_data_objects` slot (multivalued) with a range of `DataObject` to the `WorkflowExecution` parent class, so that workflow configuration files may be captured as metadata. An example of this are the toml config files that are used as part of the metabolomics, nom, and lipidomics workflows.