### PR TITLE
add activity_set to collection name change migrator

### DIFF
--- a/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
@@ -23,7 +23,8 @@ class Migrator(MigratorBase):
             "metatranscriptome_activity_set": "metatranscriptome_analysis_set",
             "nom_analysis_activity_set": "nom_analysis_set",
             "read_based_taxonomy_analysis_activity_set": "read_based_taxonomy_analysis_set",
-            "read_qc_analysis_activity_set": "read_qc_analysis_set"
+            "read_qc_analysis_activity_set": "read_qc_analysis_set",
+            "activity_set": "workflow_execution_set"
             }
 
         for current_collection_name, new_collection_name in old_to_new_names.items():


### PR DESCRIPTION
Adds to the collection name change migrator to change the collection name `activity_set` (not being used in Mongo?) to `workflow_execution_set`