### PR TITLE
Edit slots and usages to accommodate multiple detection configurations for single `MassSpectrometry` instance

### DIFF
--- a/src/data/invalid/DataGeneration-invalid-mass-spec-collection-mode.yaml
+++ b/src/data/invalid/DataGeneration-invalid-mass-spec-collection-mode.yaml
@@ -1,10 +1,13 @@
 id: nmdc:dgms-99-zUCd5N
 analyte_category: metabolome
-mass_spectrum_collection_mode: profile
+mass_spectrum_collection_modes: 
+  - profile
 acquisition_category: tandem_mass_spectrum
 acquisition_strategy: data_independent_acquisition
-resolution_category: high
-mass_analyzer: Orbitrap
+resolution_categories: 
+  - high
+mass_analyzers: 
+  - Orbitrap
 ionization_source: electrospray_ionization
 polarity_mode: negative
 alternative_identifiers:

--- a/src/data/valid/Database-mass-spectrometry.yaml
+++ b/src/data/valid/Database-mass-spectrometry.yaml
@@ -35,16 +35,16 @@ data_generation_set:
     mass_analyzers: 
       - Orbitrap
       - ion_trap
-    ionization_source: electron_ionization
+    ionization_source: electrospray_ionization
     polarity_mode: negative
     alternative_identifiers:
       - emsl:123423
     has_input:
-      - nmdc:bsm-00-red
+      - nmdc:bsm-00-red2
     add_date: 30-OCT-14 12.00.00.000000000 AM
     mod_date: 22-MAY-20 06.13.12.927000000 PM
     has_output:
-      - nmdc:dobj-00-9n9n9n
+      - nmdc:dobj-00-9n9n9x
     type: nmdc:MassSpectrometry
     associated_studies:
       - nmdc:sty-00-555xxx  

--- a/src/data/valid/Database-mass-spectrometry.yaml
+++ b/src/data/valid/Database-mass-spectrometry.yaml
@@ -1,11 +1,14 @@
 data_generation_set:
   - id: nmdc:dgms-99-zUCd5N
     analyte_category: metabolome
-    mass_spectrum_collection_mode: full_profile
+    mass_spectrum_collection_modes: 
+      - full_profile
     acquisition_category: tandem_mass_spectrum
     acquisition_strategy: data_independent_acquisition
-    resolution_category: high
-    mass_analyzer: Orbitrap
+    resolution_categories: 
+      - high
+    mass_analyzers: 
+      - Orbitrap
     ionization_source: electron_ionization
     polarity_mode: negative
     alternative_identifiers:
@@ -19,4 +22,29 @@ data_generation_set:
     type: nmdc:MassSpectrometry
     associated_studies:
       - nmdc:sty-00-555xxx
-  
+  - id: nmdc:dgms-99-zUCd5x
+    analyte_category: lipidome
+    mass_spectrum_collection_modes: 
+      - full_profile
+      - centroid
+    acquisition_category: tandem_mass_spectrum
+    acquisition_strategy: data_dependent_acquisition
+    resolution_categories: 
+      - high
+      - low
+    mass_analyzers: 
+      - Orbitrap
+      - ion_trap
+    ionization_source: electron_ionization
+    polarity_mode: negative
+    alternative_identifiers:
+      - emsl:123423
+    has_input:
+      - nmdc:bsm-00-red
+    add_date: 30-OCT-14 12.00.00.000000000 AM
+    mod_date: 22-MAY-20 06.13.12.927000000 PM
+    has_output:
+      - nmdc:dobj-00-9n9n9n
+    type: nmdc:MassSpectrometry
+    associated_studies:
+      - nmdc:sty-00-555xxx  

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -156,10 +156,10 @@ classes:
       - eluent_introduction
       - acquisition_category
       - acquisition_strategy
-      - resolution_category
-      - mass_analyzer
+      - resolution_categories
+      - mass_analyzers
       - ionization_source
-      - mass_spectrum_collection_mode
+      - mass_spectrum_collection_modes
       - polarity_mode
 
     slot_usage:
@@ -695,21 +695,24 @@ slots:
     range: PolarityModeEnum
     description: the polarity of which ions are generated and detected
 
-  mass_spectrum_collection_mode:
+  mass_spectrum_collection_modes:
     range: MassSpectrumCollectionModeEnum
     description: Indicates whether mass spectra were collected in full profile, reduced profile, or centroid mode during acquisition.
+    multivalued: true
 
   ionization_source:
     range: IonizationSourceEnum
     description: which kind of ionization source is used to introduce analytes into a mass spectrometer
 
-  mass_analyzer:
+  mass_analyzers:
     range: MassAnalyzerEnum
-    description: which kind of mass analyzer is primarily used during the spectra collection.
+    description: which kind of mass analyzer(s) used during the spectra collection.
+    multivalued: true
 
-  resolution_category:
+  resolution_categories:
     range: ResolutionCategoryEnum
-    description: whether mass spectra are collected at higher than unity resolution
+    description: whether mass spectra are collected at higher than unit resolution
+    multivalued: true
 
   acquisition_strategy:
     range: AcquisitionStrategyEnum


### PR DESCRIPTION
Addresses issue here: https://github.com/microbiomedata/nmdc-schema/issues/1910

`MassSpectrometry` class needs some slots to be multivalued to better describe the data generation process, particularly for  LC-lipidomics samples.

The following slots should be able to be multivalued (and therefore the slot names should change to be plural) and their definitions and usage updated as necessary
- `resolution_category` ->`resolution_categories`
- `mass_analyzer` ->`mass_analyzers`
- `mass_spectrum_collection_mode` ->`mass_spectrum_collection_modes`

Note that this is _independent_ of https://github.com/microbiomedata/berkeley-schema-fy24/pull/130 (creation of `Configuration` class etc).  Wherever the slots end up (on `MassSpectometry` or `MassSpectrometryConfiguration`), they need to be able to multivalued as demonstrated in the second entry in https://github.com/microbiomedata/berkeley-schema-fy24/blob/massspec_slot_updates/src/data/valid/Database-mass-spectrometry.yaml.

I will update https://github.com/microbiomedata/berkeley-schema-fy24/pull/130 once this change is merged into main on this fork. 