### PR TITLE
1943 lipid results enum

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -903,7 +903,7 @@ enums:
 
       LC-MS Lipidomics Results:
         description: >- 
-          LC-MS-based lipid assignment results table.
+          LC-MS-based lipid assignment results table
 
   DoiProviderEnum:
     see_also:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -901,6 +901,10 @@ enums:
         broad_mappings: 
           - edam.format:4005
 
+      LC-MS Lipidomics Results:
+        description: >- 
+          LC-MS-based lipid assignment results table.
+
   DoiProviderEnum:
     see_also:
       - nmdc:DoiProviderEnum


### PR DESCRIPTION
Addresses issue https://github.com/microbiomedata/nmdc-schema/issues/1943

This PR just adds a new `permissible_value` to `FileTypeEnum` to for lipidomics results: `LC-MS Lipidomics Results`