### PR TITLE
Update `slot_usage` for `git_url` in the `MetabolomicsAnalysis` class.

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -81,7 +81,7 @@ slots:
       - prov:endedAtTime
 
   git_url:
-    description: The url the points to the exact github location of a workflow.
+    description: The url that points to the exact github location of a workflow.
     range: string
     examples:
       - value: "https://github.com/microbiomedata/mg_annotation/releases/tag/0.1"

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -81,9 +81,11 @@ slots:
       - prov:endedAtTime
 
   git_url:
+    description: The url the points to the exact github location of a workflow.
     range: string
     examples:
       - value: "https://github.com/microbiomedata/mg_annotation/releases/tag/0.1"
+      - value: "https://github.com/microbiomedata/metaMS/blob/master/metaMS/gcmsWorkflow.py"
 
   execution_resource:
     range: string

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -230,8 +230,9 @@ classes:
         description: >-
           The url that points to the github location of the metabolomics workflow.
         comments: >-
-          The git_url must point to an exact workflow to differentiate lipids from 
-          GC-MS metabolomics.
+          The git_url must point to an exact workflow if multiple workflows share the
+          same github repo. For instance, to differentiate lipids from GC-MS metabolomics
+          in the MetaMS repo.
 
 
   MetaproteomicsAnalysis:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -226,14 +226,6 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmb-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
-      git_url:
-        description: >-
-          The url that points to the github location of the metabolomics workflow.
-        comments: >-
-          The git_url must point to an exact workflow if multiple workflows share the
-          same github repo. For instance, to differentiate lipids from GC-MS metabolomics 
-          and LCMS metabolomics in the MetaMS repo. An example of inexact git_url is: https://github.com/microbiomedata/metaMS. 
-          An example of an exact git_url is https://github.com/microbiomedata/metaMS/blob/master/metaMS/gcmsWorkflow.py.
 
   MetaproteomicsAnalysis:
     class_uri: "nmdc:MetaproteomicsAnalysis"

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -226,6 +226,13 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmb-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
+      git_url:
+        description: >-
+          The url that points to the github location of the metabolomics workflow.
+        comments: >-
+          The git_url must point to an exact workflow to differentiate lipids from 
+          GC-MS metabolomics.
+
 
   MetaproteomicsAnalysis:
     class_uri: "nmdc:MetaproteomicsAnalysis"

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -232,7 +232,8 @@ classes:
         comments: >-
           The git_url must point to an exact workflow if multiple workflows share the
           same github repo. For instance, to differentiate lipids from GC-MS metabolomics 
-          and LCMS metabolomics in the MetaMS repo.
+          and LCMS metabolomics in the MetaMS repo. An example of inexact git_url is: https://github.com/microbiomedata/metaMS. 
+          An example of an exact git_url is https://github.com/microbiomedata/metaMS/blob/master/metaMS/gcmsWorkflow.py.
 
 
   MetaproteomicsAnalysis:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -231,8 +231,8 @@ classes:
           The url that points to the github location of the metabolomics workflow.
         comments: >-
           The git_url must point to an exact workflow if multiple workflows share the
-          same github repo. For instance, to differentiate lipids from GC-MS metabolomics
-          in the MetaMS repo.
+          same github repo. For instance, to differentiate lipids from GC-MS metabolomics 
+          and LCMS metabolomics in the MetaMS repo.
 
 
   MetaproteomicsAnalysis:


### PR DESCRIPTION
This PR addresses issue: https://github.com/microbiomedata/nmdc-schema/issues/1942

It updates the slot_usage in the MetabolomicsAnalysis class for the git_url slot, so it clarifies that the url must point to an exact workflow for workflows that share the same github repo.