### PR TITLE
remove quotes from `WorkflowChain` `class_uri`

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -341,7 +341,7 @@ classes:
       - OBI:0000070
       - ISA:Assay
   WorkflowChain:
-    class_uri: "nmdc:WorkflowChain"
+    class_uri: nmdc:WorkflowChain
     is_a: PlannedProcess
     description: >-
       A workflow chain is a collection of Workflow Execution(s) that


### PR DESCRIPTION
I am not able to mint ids for WorkflowChain in the nmdc runtime because it does not recognize `nmdc:WorkflowChain` as a class. I believe it is because of the quotes around it. This PR removes them.