### PR TITLE
no-element-uri-quotes

### DIFF
--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -35,7 +35,7 @@ default_range: string
 
 classes:
   GenomeFeature:
-    class_uri: "nmdc:GenomeFeature"
+    class_uri: nmdc:GenomeFeature
     description: >-
       A feature localized to an interval along a genome
     comments:
@@ -61,7 +61,7 @@ classes:
         required: true
 
   FunctionalAnnotationTerm:
-    class_uri: "nmdc:FunctionalAnnotationTerm"
+    class_uri: nmdc:FunctionalAnnotationTerm
     aliases:
       - function
       - FunctionalAnnotation
@@ -74,7 +74,7 @@ classes:
       - Retaining this even after removing Reaction. See todos on the Pathway and OrthologyGroup subclasses.
 
   Pathway:
-    class_uri: "nmdc:Pathway"
+    class_uri: nmdc:Pathway
     aliases:
       - biological process
       - metabolic pathway
@@ -92,7 +92,7 @@ classes:
       - is Pathway instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
 
   OrthologyGroup:
-    class_uri: "nmdc:OrthologyGroup"
+    class_uri: nmdc:OrthologyGroup
     is_a: FunctionalAnnotationTerm
     description: >-
       A set of genes or gene products in which all members are orthologous
@@ -112,7 +112,7 @@ classes:
       - is OrthologyGroup instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
 
   FunctionalAnnotation:
-    class_uri: "nmdc:FunctionalAnnotation"
+    class_uri: nmdc:FunctionalAnnotation
     description: >-
       An assignment of a function term (e.g. reaction or pathway) that is executed by a gene product, 
       or which the gene product plays an active role in.

--- a/src/schema/attribute_values.yaml
+++ b/src/schema/attribute_values.yaml
@@ -21,7 +21,7 @@ classes:
       - type
 
   QuantityValue:
-    class_uri: "nmdc:QuantityValue"
+    class_uri: nmdc:QuantityValue
     is_a: AttributeValue
     description: A simple quantity, e.g. 2cm
     slots:
@@ -41,7 +41,7 @@ classes:
       - schema:QuantityValue
 
   ImageValue:
-    class_uri: "nmdc:ImageValue"
+    class_uri: nmdc:ImageValue
     is_a: AttributeValue
     description: An attribute value representing an image.
     slots:
@@ -50,7 +50,7 @@ classes:
       - display_order
 
   PersonValue:
-    class_uri: "nmdc:PersonValue"
+    class_uri: nmdc:PersonValue
     is_a: AttributeValue
     description: An attribute value representing a person
     slots:
@@ -80,19 +80,19 @@ classes:
         annotations:
           display_hint: First name, middle initial, and last name of this person.
   TextValue:
-    class_uri: "nmdc:TextValue"
+    class_uri: nmdc:TextValue
     is_a: AttributeValue
     description: A basic string value
     slots:
       - language
 
   #  UrlValue:
-  #    class_uri: "nmdc:UrlValue"
+  #    class_uri: nmdc:UrlValue
   #    is_a: AttributeValue
   #    description: A value that is a string that conforms to URL syntax
 
   TimestampValue:
-    class_uri: "nmdc:TimestampValue"
+    class_uri: nmdc:TimestampValue
     is_a: AttributeValue
     description: A value that is a timestamp. The range should be ISO-8601
     notes:
@@ -132,7 +132,7 @@ classes:
         required: true
 
   GeolocationValue:
-    class_uri: "nmdc:GeolocationValue"
+    class_uri: nmdc:GeolocationValue
     is_a: AttributeValue
     description: A normalized value for a location on the earth's surface
     slots:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -16,7 +16,7 @@ imports:
 classes:
 
   NamedThing:
-    class_uri: "nmdc:NamedThing"
+    class_uri: nmdc:NamedThing
     description: "a databased entity or concept/class"
     abstract: true
     slots:
@@ -26,7 +26,7 @@ classes:
       - alternative_identifiers
       - type
   OntologyClass:
-    class_uri: "nmdc:OntologyClass"
+    class_uri: nmdc:OntologyClass
     is_a: NamedThing
     notes:
       - The identifiers for terms from external ontologies can't have their ids constrained to the nmdc namespace
@@ -42,7 +42,7 @@ classes:
       - type
 
   MaterialEntity:
-    class_uri: "nmdc:MaterialEntity"
+    class_uri: nmdc:MaterialEntity
     abstract: true
     aliases:
       - Material
@@ -105,7 +105,7 @@ classes:
     see_also:
       - https://casrai.org/credit/
   Doi:
-    class_uri: "nmdc:Doi"
+    class_uri: nmdc:Doi
     aliases:
       - DOIs
       - digital object identifiers
@@ -341,7 +341,7 @@ classes:
       - OBI:0000070
       - ISA:Assay
   WorkflowChain:
-    class_uri: "nmdc:WorkflowChain"
+    class_uri: nmdc:WorkflowChain
     is_a: PlannedProcess
     description: >-
       A workflow chain is a collection of Workflow Execution(s) that
@@ -372,7 +372,7 @@ classes:
           output data and the metadata of the Data Generation.
 
   WorkflowExecution:
-    class_uri: "nmdc:WorkflowExecution"
+    class_uri: nmdc:WorkflowExecution
     is_a: PlannedProcess
     aliases:
       - analysis

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -146,7 +146,7 @@ classes:
           interpolated: true
 
   MetagenomeAnnotation:
-    class_uri: "nmdc:MetagenomeAnnotation"
+    class_uri: nmdc:MetagenomeAnnotation
     description: A workflow execution activity that provides functional and structural annotation of assembled metagenome contigs
     is_a: WorkflowExecution
     slots:
@@ -1202,7 +1202,7 @@ classes:
       - OBI:0000094
 
   PortionOfSubstance:
-    class_uri: "nmdc:PortionOfSubstance"
+    class_uri: nmdc:PortionOfSubstance
     title: Portion of a Substance
     mappings:
       - schema:Substance
@@ -1218,7 +1218,7 @@ classes:
       - volume
 
   ProcessedSample:
-    class_uri: "nmdc:ProcessedSample"
+    class_uri: nmdc:ProcessedSample
     is_a: MaterialEntity
     title: Processed Sample
     slots:
@@ -1235,7 +1235,7 @@ classes:
           interpolated: true
 
   Site:
-    class_uri: "nmdc:Site"
+    class_uri: nmdc:Site
     abstract: true
     is_a: MaterialEntity
     title: Site
@@ -1253,7 +1253,7 @@ classes:
     class_uri: 'nmdc:EnvironmentalMaterialTerm'
 
   MagBin:
-    class_uri: "nmdc:MagBin"
+    class_uri: nmdc:MagBin
     slots:
       - bin_name
       - bin_quality
@@ -1277,7 +1277,7 @@ classes:
       - type
 
   MetaboliteIdentification:
-    class_uri: "nmdc:MetaboliteIdentification"
+    class_uri: nmdc:MetaboliteIdentification
     description: This is used to link a metabolomics analysis workflow to a specific metabolite
     slots:
       - alternative_identifiers
@@ -1286,7 +1286,7 @@ classes:
       - type
 
   PeptideQuantification:
-    class_uri: "nmdc:PeptideQuantification"
+    class_uri: nmdc:PeptideQuantification
     description: This is used to link a metaproteomics analysis workflow to a specific peptide sequence and related information
     slots:
       - type
@@ -1298,7 +1298,7 @@ classes:
       - peptide_sum_masic_abundance
 
   ProteinQuantification:
-    class_uri: "nmdc:ProteinQuantification"
+    class_uri: nmdc:ProteinQuantification
     description: This is used to link a metaproteomics analysis workflow to a specific protein
     slots:
       - all_proteins
@@ -1314,7 +1314,7 @@ classes:
         description: the grouped list of protein identifiers associated with the peptide sequences that were grouped to a best protein
 
   ChemicalEntity:
-    class_uri: "nmdc:ChemicalEntity"
+    class_uri: nmdc:ChemicalEntity
     aliases:
       - metabolite
       - chemical substance
@@ -1348,7 +1348,7 @@ classes:
       - biolink:ChemicalSubstance
 
   GeneProduct:
-    class_uri: "nmdc:GeneProduct"
+    class_uri: nmdc:GeneProduct
     is_a: NamedThing
     description: A molecule encoded by a gene that has an evolved function
     notes:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -169,7 +169,7 @@ classes:
           interpolated: true
   
   FunctionalAnnotationAggMember:
-    class_uri: "nmdc:FunctionalAnnotationAggMember"
+    class_uri: nmdc:FunctionalAnnotationAggMember
     slots:
       - metagenome_annotation_id
       - gene_function_id

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -16,7 +16,7 @@ default_range: string
 
 classes:
   MetagenomeAssembly:
-    class_uri: "nmdc:MetagenomeAssembly"
+    class_uri: nmdc:MetagenomeAssembly
     description: A workflow execution activity that converts sequencing reads into an assembled metagenome.
     comments:
       - instances of this class may use a de novo assembly strategy in most or all cases relevant to NMDC
@@ -60,7 +60,7 @@ classes:
           interpolated: true
 
   MetatranscriptomeAssembly:
-    class_uri: "nmdc:MetatranscriptomeAssembly"
+    class_uri: nmdc:MetatranscriptomeAssembly
     is_a: WorkflowExecution
     in_subset:
       - workflow subset
@@ -102,7 +102,7 @@ classes:
 
 
   MetatranscriptomeAnnotation:
-    class_uri: "nmdc:MetatranscriptomeAnnotation"
+    class_uri: nmdc:MetatranscriptomeAnnotation
     is_a: WorkflowExecution
     slots:
       - img_identifiers
@@ -118,7 +118,7 @@ classes:
         maximum_cardinality: 1
 
   MetatranscriptomeAnalysis:
-    class_uri: "nmdc:MetatranscriptomeAnalysis"
+    class_uri: nmdc:MetatranscriptomeAnalysis
     is_a: WorkflowExecution
     description: >-
       A metatranscriptome activity that e.g. pools assembly and annotation activity.
@@ -137,7 +137,7 @@ classes:
 
 
   MagsAnalysis:
-    class_uri: "nmdc:MagsAnalysis"
+    class_uri: nmdc:MagsAnalysis
     description: A workflow execution activity that uses computational binning tools to group assembled contigs into genomes
     title: Metagenome-Assembled Genome analysis activity
     is_a: WorkflowExecution
@@ -162,7 +162,7 @@ classes:
 
 
   MetagenomeSequencing:
-    class_uri: "nmdc:MetagenomeSequencing"
+    class_uri: nmdc:MetagenomeSequencing
     description: Initial sequencing activity that precedes any analysis.  This activity has output(s) that are the raw sequencing data.
     title: Metagenome sequencing activity
     is_a: WorkflowExecution
@@ -177,7 +177,7 @@ classes:
 
 
   ReadQcAnalysis:
-    class_uri: "nmdc:ReadQcAnalysis"
+    class_uri: nmdc:ReadQcAnalysis
     description: A workflow execution activity that performs quality control on raw Illumina reads including quality trimming, artifact removal, linker trimming, adapter trimming, spike-in removal, and human/cat/dog/mouse/microbe contaminant removal
     title: Read quality control analysis activity
     is_a: WorkflowExecution
@@ -198,7 +198,7 @@ classes:
           interpolated: true
 
   ReadBasedTaxonomyAnalysis:
-    class_uri: "nmdc:ReadBasedTaxonomyAnalysis"
+    class_uri: nmdc:ReadBasedTaxonomyAnalysis
     description: A workflow execution activity that performs taxonomy classification using sequencing reads
     title: Read based analysis activity
     is_a: WorkflowExecution
@@ -213,7 +213,7 @@ classes:
 
 
   MetabolomicsAnalysis:
-    class_uri: "nmdc:MetabolomicsAnalysis"
+    class_uri: nmdc:MetabolomicsAnalysis
     is_a: WorkflowExecution
     in_subset:
       - workflow subset
@@ -228,7 +228,7 @@ classes:
           interpolated: true
 
   MetaproteomicsAnalysis:
-    class_uri: "nmdc:MetaproteomicsAnalysis"
+    class_uri: nmdc:MetaproteomicsAnalysis
     is_a: WorkflowExecution
     in_subset:
       - workflow subset
@@ -242,7 +242,7 @@ classes:
           interpolated: true
 
   NomAnalysis:
-    class_uri: "nmdc:NomAnalysis"
+    class_uri: nmdc:NomAnalysis
     is_a: WorkflowExecution
     in_subset:
       - workflow subset


### PR DESCRIPTION
This PR removes quotes from aground the values of any slot whose name ends in `_uri`

This is an experiment to see whether quotes around `class_uri`s break requests to  mint NMDC identifiers form the swagger interface