### PR TITLE
Create `SchemaView` in more environment-agnostic way (in migrator)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ create-data-harmonizer:
 all: site
 
 # TODO: Document this make target.
-site: clean site-clean gen-project gendoc migration-doctests nmdc_schema/gold-to-mixs.sssom.tsv accepting-legacy-ids-all
+site: clean site-clean gen-project gendoc nmdc_schema/gold-to-mixs.sssom.tsv accepting-legacy-ids-all
 
 # may change files in nmdc_schema/ or project/. uncommitted changes are not tolerated by mkd-gh-deploy
 
@@ -120,9 +120,9 @@ gen-project: $(PYMODEL) # depends on src/schema/mixs.yaml # can be nuked with mi
 		-d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
 		cp project/jsonschema/nmdc.schema.json  $(PYMODEL)
 
-
-test: examples-clean site accepting-legacy-ids-all test-python examples/output
-only-test: examples-clean accepting-legacy-ids-all test-python examples/output
+# TODO: Document these make targets.
+test: examples-clean site accepting-legacy-ids-all test-python migration-doctests examples/output
+only-test: examples-clean accepting-legacy-ids-all test-python migration-doctests examples/output
 
 test-schema:
 	# keep these in sync between PROJECT_FOLDERS and the includes/excludes for gen-project and test-schema

--- a/nmdc_schema/migrators/migrator_from_X_to_PR10.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR10.py
@@ -9,10 +9,9 @@ def create_schema_view() -> SchemaView:
     """
     Returns a LinkML SchemaView instance that can be used to traverse the schema.
     
-    >>> sv = create_schema_view()
-    >>> isinstance(sv, SchemaView)
+    >>> isinstance(create_schema_view(), SchemaView)
     True
-    >>> hasattr(sv, "schema")
+    >>> hasattr(create_schema_view(), "schema")
     True
     """
     schema_definition = get_nmdc_schema_definition()

--- a/nmdc_schema/migrators/migrator_from_X_to_PR10.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR10.py
@@ -11,8 +11,6 @@ def create_schema_view() -> SchemaView:
     
     >>> isinstance(create_schema_view(), SchemaView)
     True
-    >>> hasattr(create_schema_view(), "schema")
-    True
     """
     schema_definition = get_nmdc_schema_definition()
     schema_view = SchemaView(schema_definition)

--- a/nmdc_schema/migrators/migrator_from_X_to_PR10.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR10.py
@@ -1,6 +1,23 @@
-from nmdc_schema.migrators.migrator_base import MigratorBase
 from typing import Optional
+
+from nmdc_schema.migrators.migrator_base import MigratorBase
+from nmdc_schema.nmdc_data import get_nmdc_schema_definition
 from linkml_runtime import SchemaView
+
+
+def create_schema_view() -> SchemaView:
+    """
+    Returns a LinkML SchemaView instance that can be used to traverse the schema.
+    
+    >>> sv = create_schema_view()
+    >>> isinstance(sv, SchemaView)
+    True
+    >>> hasattr(sv, "schema")
+    True
+    """
+    schema_definition = get_nmdc_schema_definition()
+    schema_view = SchemaView(schema_definition)
+    return schema_view
 
 
 class Migrator(MigratorBase):
@@ -13,7 +30,7 @@ class Migrator(MigratorBase):
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
 
         # Get a dictionary of slots and the class uris of their range if they have inlined classes as their range.
-        view = SchemaView("src/schema/nmdc.yaml")
+        view = create_schema_view()
 
         slots_with_inlined_classes = {}
         classes_with_inlined_classes = ["Biosample", "Study", "Extraction", "MetabolomicsAnalysis" , "MetaproteomicsAnalysis", "MagsAnalysis"]


### PR DESCRIPTION
In this branch, I replaced a hard-coded file path with the return value of a function that handles loading files in a more portable way. This is an approach I saw in the `nmdc-runtime` repository. My goal is to be able to run this migrator when importing `nmdc-schema` as a package from PyPI (as opposed to while developing `nmdc-schema`, itself).

Associated GitHub Issue: https://github.com/microbiomedata/nmdc-schema/issues/1970