### PR TITLE
Modify `Extraction` class to accommodate solid phase extractions

### DIFF
--- a/src/data/valid/Extraction-SPE.yaml
+++ b/src/data/valid/Extraction-SPE.yaml
@@ -1,10 +1,11 @@
-id: nmdc:cspro-99-oW43DzG0
-type: nmdc:ChromatographicSeparationProcess
+id: nmdc:extrp-99-oW43DzG0
+type: nmdc:Extraction
 has_input:
   - nmdc:procsm-11-9gjxns61
 has_output:
   - nmdc:procsm-11-05g48p90
   - nmdc:procsm-11-05g48p91
+extraction_category: solid_phase
 stationary_phase: "CN"
 ordered_mobile_phases:
   - type: nmdc:MobilePhaseSegment

--- a/src/data/valid/Extraction-SPE.yaml
+++ b/src/data/valid/Extraction-SPE.yaml
@@ -6,6 +6,7 @@ has_output:
   - nmdc:procsm-11-05g48p90
   - nmdc:procsm-11-05g48p91
 extraction_category: solid_phase
+extraction_target: natural_organic_matter
 stationary_phase: "CN"
 ordered_mobile_phases:
   - type: nmdc:MobilePhaseSegment

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -1022,6 +1022,9 @@ enums:
       RNA: { }
       metabolite: { }
       protein: { }
+      natural_organic_matter:
+        aliases:
+          - NOM
 
   ProcessingInstitutionEnum:
     notes:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -278,6 +278,8 @@ classes:
       - extraction_target
       - input_mass
       - volume
+      - ordered_mobile_phases
+      - stationary_phase
     slot_usage:
       has_output:
         required: true
@@ -713,7 +715,7 @@ enums:
       liquid_liquid:
         aliases:
           - liquid_liquid_extraction
-            
+
   SamplePortionEnum:
     permissible_values:
       supernatant:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -711,7 +711,7 @@ enums:
       solid_phase:
         aliases:
           - solid_phase_extraction
-          - spe
+          - SPE
       liquid_liquid:
         aliases:
           - liquid_liquid_extraction

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -273,7 +273,7 @@ classes:
     exact_mappings:
       - OBI:0302884
     slots:
-      #      - extractant
+      - extraction_category
       - substances_used
       - extraction_target
       - input_mass
@@ -703,7 +703,17 @@ enums:
       solid_phase_extraction:
         aliases:
           - SPE
-  
+
+  ExtractionCategoryEnum:
+    permissible_values:
+      solid_phase:
+        aliases:
+          - solid_phase_extraction
+          - spe
+      liquid_liquid:
+        aliases:
+          - liquid_liquid_extraction
+            
   SamplePortionEnum:
     permissible_values:
       supernatant:
@@ -819,6 +829,11 @@ slots:
       - MIXS:0000111
     domain: PlannedProcess
     range: QuantityValue
+
+  extraction_category:
+    range: ExtractionCategoryEnum
+    description: The general type of extraction process used, i.e. solid phase, liquid-liquid, etc.
+    domain: Extraction
 
   library_type:
     title: library type


### PR DESCRIPTION
First step of addressing https://github.com/microbiomedata/nmdc-schema/issues/1920.  A following PR with deal with the remainder 

This PR modifies the existing `Extraction` class to accommodate for solid phase extractions for NOM which are currently modeled using the `ChromatographicSeparationProcess` class.  

Three slots are added to the Extraction class: `ordered_mobile_phases`, `stationary_phase`, and `extraction_category`.  `extraction_category` is a new slot with range of new Enum `ExtractionCategoryEnum` to specify what type of extraction - solid phase or liquid/liquid phase extraction which are the two I know we will need to capture for metabolomis and NOM.  

One new permissible value was added to `ExtractionTargetEnum` to accommodate for NOM extractions (the main target of solid phase extractions).

An existing valid example was modified to show an example of a modeled NOM solid phase extraction (Extraction-SPE.yaml).