### PR TITLE
Fix MassSpectrometry ID issue and use of eluent_introduction_category slot

### DIFF
--- a/src/data/valid/Database-mass-spectrometry.yaml
+++ b/src/data/valid/Database-mass-spectrometry.yaml
@@ -1,52 +1,36 @@
-#data_generation_set: # had been using dgms typecode
-#  - id: nmdc:omprc-99-zUCd5N
-#    type: nmdc:MassSpectrometry
+data_generation_set: 
+  - id: nmdc:dgms-99-zUCd5N
+    type: nmdc:MassSpectrometry
 #    eluent_introduction_category: liquid_chromatography
-#    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
-#    has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
-#    analyte_category: lipidome
-#    has_input:
-#      - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
-#    start_date: 30-OCT-14 01.00.00.000000000 AM
-#    end_date: 30-OCT-14 01.30.00.000000000 AM
-#    add_date: 07-MAY-24 12.00.00.000000000 AM
-#    mod_date: 07-MAY-24 12.00.00.000000000 AM
-#    has_output:
-#      - nmdc:dobj-00-msdem1
-#    associated_studies:
-#      - nmdc:sty-00-555xxx
-#  - id: nmdc:omprc-99-zUCd5x
-#    type: nmdc:MassSpectrometry
+    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
+    has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
+    analyte_category: lipidome
+    has_input:
+      - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
+    start_date: 30-OCT-14 01.00.00.000000000 AM
+    end_date: 30-OCT-14 01.30.00.000000000 AM
+    add_date: 07-MAY-24 12.00.00.000000000 AM
+    mod_date: 07-MAY-24 12.00.00.000000000 AM
+    has_output:
+      - nmdc:dobj-00-msdem1
+    associated_studies:
+      - nmdc:sty-00-555xxx
+  - id: nmdc:dgms-99-zUCd5x
+    type: nmdc:MassSpectrometry
 #    eluent_introduction_category: liquid_chromatography
-#    analyte_category: lipidome
-#    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
-#    has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
-#    has_input:
-#      - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
-#    start_date: 31-OCT-14 01.00.00.000000000 AM
-#    end_date: 31-OCT-14 01.30.00.000000000 AM
-#    add_date: 07-MAY-24 12.00.00.000000000 AM
-#    mod_date: 07-MAY-24 12.00.00.000000000 AM
-#    has_output:
-#      - nmdc:dobj-00-msdem2
-#    associated_studies:
-#      - nmdc:sty-00-555xxx
-#  - id: nmdc:dgms-99-zUCd5x
-#    type: nmdc:MassSpectrometry
-#    eluent_introduction_category: liquid_chromatography
-#    analyte_category: lipidome
-#    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
-#    has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
-#    has_input:
-#      - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
-#    start_date: 31-OCT-14 01.00.00.000000000 AM
-#    end_date: 31-OCT-14 01.30.00.000000000 AM
-#    add_date: 07-MAY-24 12.00.00.000000000 AM
-#    mod_date: 07-MAY-24 12.00.00.000000000 AM
-#    has_output:
-#      - nmdc:dobj-00-msdem2
-#    associated_studies:
-#      - nmdc:sty-00-555xxx
+    analyte_category: lipidome
+    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
+    has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
+    has_input:
+      - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
+    start_date: 31-OCT-14 01.00.00.000000000 AM
+    end_date: 31-OCT-14 01.30.00.000000000 AM
+    add_date: 07-MAY-24 12.00.00.000000000 AM
+    mod_date: 07-MAY-24 12.00.00.000000000 AM
+    has_output:
+      - nmdc:dobj-00-msdem2
+    associated_studies:
+      - nmdc:sty-00-555xxx
 
 # example data objects for the mass spectrometry data generation set
 data_object_set:

--- a/src/data/valid/Database-mass-spectrometry.yaml
+++ b/src/data/valid/Database-mass-spectrometry.yaml
@@ -1,7 +1,7 @@
 data_generation_set: 
   - id: nmdc:dgms-99-zUCd5N
     type: nmdc:MassSpectrometry
-#    eluent_introduction_category: liquid_chromatography
+    eluent_introduction_category: liquid_chromatography
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
     has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
     analyte_category: lipidome
@@ -17,7 +17,7 @@ data_generation_set:
       - nmdc:sty-00-555xxx
   - id: nmdc:dgms-99-zUCd5x
     type: nmdc:MassSpectrometry
-#    eluent_introduction_category: liquid_chromatography
+    eluent_introduction_category: liquid_chromatography
     analyte_category: lipidome
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
     has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -1,17 +1,18 @@
-data_generation_set:
+data_generation_set: #this validates elsewhere as a standalone MassSpectrometry object
   - id: nmdc:dgms-99-oW43DzG1
     type: nmdc:MassSpectrometry
-#    has_input:
-#      - nmdc:procsm-11-9gjxns61                                 #random example process sample
-#    has_output:
-#      - nmdc:dobj-11-9n9n9n                                     #defined below
-#    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG0 #defined below
-#    has_chromatography_configuration: nmdc:chrocon-99-oW43DzG1  #defined below
+    has_input:
+      - nmdc:procsm-11-9gjxns61                                 #random example process sample
+    has_output:
+      - nmdc:dobj-11-9n9n9n                                     #defined below
+    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG0 #defined below
+    has_chromatography_configuration: nmdc:chrocon-99-oW43DzG1  #defined below
 #    eluent_introduction_category: gas_chromatography
-#    has_calibration: nmdc:calib-99-zUCd5Q                       #defined below
-#    analyte_category: metabolome
-#    associated_studies:
-#      - nmdc:sty-00-555xxx
+    has_calibration: nmdc:calib-99-zUCd5Q                       #defined below
+    analyte_category: metabolome
+    associated_studies:
+      - nmdc:sty-00-555xxx
+      
 calibration_set:
   - id: nmdc:calib-99-zUCd5Q
     type: nmdc:CalibrationInformation

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -1,4 +1,4 @@
-data_generation_set: #this validates elsewhere as a standalone MassSpectrometry object
+data_generation_set: 
   - id: nmdc:dgms-99-oW43DzG1
     type: nmdc:MassSpectrometry
     has_input:
@@ -12,7 +12,7 @@ data_generation_set: #this validates elsewhere as a standalone MassSpectrometry 
     analyte_category: metabolome
     associated_studies:
       - nmdc:sty-00-555xxx
-      
+
 calibration_set:
   - id: nmdc:calib-99-zUCd5Q
     type: nmdc:CalibrationInformation

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -7,7 +7,7 @@ data_generation_set:
       - nmdc:dobj-11-9n9n9n                                     #defined below
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG0 #defined below
     has_chromatography_configuration: nmdc:chrocon-99-oW43DzG1  #defined below
-#    eluent_introduction_category: gas_chromatography
+    eluent_introduction_category: gas_chromatography
     has_calibration: nmdc:calib-99-zUCd5Q                       #defined below
     analyte_category: metabolome
     associated_studies:

--- a/src/data/valid/MassSpectrometry-NOM.yaml
+++ b/src/data/valid/MassSpectrometry-NOM.yaml
@@ -5,7 +5,7 @@ has_input:
 has_output:
   - nmdc:dobj-00-9n9n9n
 has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG0
-#eluent_introduction_category: direct_infusion_syringe
+eluent_introduction_category: direct_infusion_syringe
 analyte_category: nom
 associated_studies:
   - nmdc:sty-00-555xxx

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -327,10 +327,6 @@ classes:
       - principal_investigator
       - instrument_used
     slot_usage:
-      id:
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}{id_version}{id_locus}"
-          interpolated: true
       has_input:
         required: true
         pattern: "^nmdc:(bsm|procsm)-[0-9][a-z]{0,6}[0-9]-[A-Za-z0-9]{1,}(\\.[A-Za-z0-9]{1,})*(_[A-Za-z0-9_\\.-]+)?$"

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -141,7 +141,7 @@ classes:
     exact_mappings:
       - CHMO:0000470
     slots:
-#      - eluent_introduction_category
+      - eluent_introduction_category
       - has_mass_spectrometry_configuration
       - has_chromatography_configuration
       - has_calibration
@@ -150,31 +150,31 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(dgms|omprc)-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
-#    rules:
-#    - title: has_calibration_required_if_gc
-#      description: >-
-#        If eluent_introduction_category is gas_chromatography, then has_calibration is required.
-#      preconditions:
-#        slot_conditions:
-#          eluent_introduction_category:
-#            equals_string: gas_chromatography
-#      postconditions:
-#        slot_conditions:
-#          has_calibration:
-#            required: true
-#    - title: has_chromatography_configuration_required_if_lc_or_gc
-#      description: >-
-#        If eluent_introduction_category is liquid_chromatography or gas_chromatography, then has_chromatography_configuration is required.
-#      preconditions:
-#        slot_conditions:
-#          eluent_introduction_category:
-#            any_of:
-#            - equals_string: liquid_chromatography
-#            - equals_string: gas_chromatography
-#      postconditions:
-#        slot_conditions:
-#          has_chromatography_configuration:
-#            required: true
+    rules:
+    - title: has_calibration_required_if_gc
+      description: >-
+        If eluent_introduction_category is gas_chromatography, then has_calibration is required.
+      preconditions:
+        slot_conditions:
+          eluent_introduction_category:
+            equals_string: gas_chromatography
+      postconditions:
+        slot_conditions:
+          has_calibration:
+            required: true
+    - title: has_chromatography_configuration_required_if_lc_or_gc
+      description: >-
+        If eluent_introduction_category is liquid_chromatography or gas_chromatography, then has_chromatography_configuration is required.
+      preconditions:
+        slot_conditions:
+          eluent_introduction_category:
+            any_of:
+            - equals_string: liquid_chromatography
+            - equals_string: gas_chromatography
+      postconditions:
+        slot_conditions:
+          has_chromatography_configuration:
+            required: true
 
 
   Configuration:
@@ -625,6 +625,21 @@ enums:
       positive: { }
       negative: { }
 
+  EluentIntroductionCategoryEnum:
+    permissible_values:
+      liquid_chromatography:
+        aliases:
+          - LC
+        description: The processed sample is introduced into the mass spectrometer through a liquid chromatography process.
+      gas_chromatography:
+        aliases:
+          - GC
+        description: The processed sample is introduced into the mass spectrometer through a gas chromatography process.
+      direct_infusion_syringe:
+        description: The processed sample is introduced into the mass spectrometer through a direct infusion process using a syringe.
+      direct_infusion_autosampler:
+        description: The processed sample is introduced into the mass spectrometer through a direct infusion process using an autosampler.
+
   LibraryTypeEnum:
     # start using the right case for enum names
     # we have other slots which need a DNA or RNA answer, so maybe we should make this enum name more generic
@@ -774,9 +789,9 @@ slots:
     range: AcquisitionCategoryEnum
     description: whether only survey or tandem mass spectra are part of the experiment
 
-#  eluent_introduction_category:
-#    range: EluentIntroductionCategoryEnum
-#    description: how a processed sample is introduced into a mass spectrometer, for example liquid chromatography or direct infusion through a syringe
+  eluent_introduction_category:
+    range: EluentIntroductionCategoryEnum
+    description: how a processed sample is introduced into a mass spectrometer, for example liquid chromatography or direct infusion through a syringe
 
   has_mass_spectrometry_configuration:
     range: MassSpectrometryConfiguration


### PR DESCRIPTION
This should resolve https://github.com/microbiomedata/nmdc-schema/issues/1972.

Removed slot_usage for id on DataGeneration.
Added back EluentIntroductionEnum (not sure why/how that was made wonky during the back merge)
Fixed example mass spectrometry yamls
Re-instated use of the eluent_introduction_category slot on MassSpectrometry and associated rules