### PR TITLE
Fix `execution_resource`global vs. slot usage inconsistencies

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -565,33 +565,6 @@ slots:
       - For example Low read count from a sequencer, malformed fastq files, etc)
 
 enums:
-  ExecutionResourceEnum:
-    see_also:
-      - nmdc:DoiProviderEnum
-      - nmdc:ProcessingInstitutionEnum
-      - nmdc:ExecutionResourceEnum
-    permissible_values:
-      NERSC-Cori:
-        description: NERSC Cori supercomputer
-        aliases:
-          - Cori
-      NERSC-Perlmutter:
-        description: NERSC Perlmutter supercomputer
-        aliases:
-          - Perlmutter
-          - Saul
-      EMSL:
-        description: Environmental Molecular Sciences Laboratory
-      EMSL-RZR:
-        description: Environmental Molecular Sciences Laboratory RZR cluster
-        aliases:
-          - RZR
-      JGI:
-        description: Joint Genome Institute
-      LANL-B-div:
-        description: LANL Bioscience Division
-        aliases:
-          - B-div
   CreditEnum:
     permissible_values:
       Conceptualization:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -430,7 +430,6 @@ classes:
       #   required: true
       execution_resource:
         required: true
-        range: ExecutionResourceEnum
       part_of:
         required: true
         description: >-

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -88,7 +88,7 @@ slots:
       - value: "https://github.com/microbiomedata/metaMS/blob/master/metaMS/gcmsWorkflow.py"
 
   execution_resource:
-    range: string
+    range: ExecutionResourceEnum
     description: The computing resource or facility where the workflow was executed.
     examples:
       - value: NERSC-Cori
@@ -569,6 +569,34 @@ slots:
 #  #    range: InstrumentValue
 
 enums:
+
+  ExecutionResourceEnum:
+    see_also:
+      - nmdc:DoiProviderEnum
+      - nmdc:ProcessingInstitutionEnum
+      - nmdc:ExecutionResourceEnum
+    permissible_values:
+      NERSC-Cori:
+        description: NERSC Cori supercomputer
+        aliases:
+          - Cori
+      NERSC-Perlmutter:
+        description: NERSC Perlmutter supercomputer
+        aliases:
+          - Perlmutter
+          - Saul
+      EMSL:
+        description: Environmental Molecular Sciences Laboratory
+      EMSL-RZR:
+        description: Environmental Molecular Sciences Laboratory RZR cluster
+        aliases:
+          - RZR
+      JGI:
+        description: Joint Genome Institute
+      LANL-B-div:
+        description: LANL Bioscience Division
+        aliases:
+          - B-div
 
   FileTypeEnum:
     permissible_values:


### PR DESCRIPTION
I noticed in the documentation that `execution_resource` was showing up as having a `range` of `string` despite us implementing an `ExecutionResourceEnum` as its `range` in Berkeley. This was because the global definition of `execution_resource` had a range of `string` while under the `WorkflowExecution` class it had a range of `ExecutionResourceEnum`. I fixed this by:

- changing the `range` on the global definition of `execution_resource` from `string` to `ExecutionResourceEnum`
- I had to move the definition of `ExecutionResourceEnum` over to the same file `execution_resource` is globally defined on so it would pass the tests
- I kept the slot usage for `execution_resource` on `WorkflowExecution` to make it required. 