### PR TITLE
Migrator to remove `designated_class` slott

### DIFF
--- a/nmdc_schema/migrators/migrator_from_X_to_PR10.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR10.py
@@ -123,6 +123,12 @@ class Migrator(MigratorBase):
         if inlined_slots:
             for slot, uri in inlined_slots.items():
                 self.add_type_to_inlined_classes(document, slot, uri)
+
+    def remove_designated_class(self, document:dict):
+
+        if "designated_class" in document:
+            document.pop('designated_class')
+            self.logger.info(f"Removing slot designated_class from doc {document['id']}")
                 
         return document
 


### PR DESCRIPTION
This migration was missed. It removes the `designated_class` slot from all classes that use it. 

I found it doing schema validation checks and could not find the PR that actually removed this slot, so the migrator is called `unknown`. Let me know if you want me to change that.

This migrator does not rely on any other migrators so can occur wherever.