### PR TITLE
Migrator to remove `designated_class` slot

### DIFF
--- a/nmdc_schema/migrators/migrator_from_X_to_unknown.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_unknown.py
@@ -1,0 +1,44 @@
+
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+class Migrator(MigratorBase):
+    """
+    Migrates data from X to an unknown PR, namely removes the 'designated_class' slot from
+    all classes it is used.
+    """
+
+    _from_version = "X"
+    _to_version = "unknown"
+
+    def upgrade(self):
+        r"""
+        Migrates the database from conforming to the original schema, to conforming to the new schema.
+        """
+
+        collection_names = [
+            "OmicsProcessing",
+            "Pooling",
+            "LibraryPreparation",
+            "Extraction"
+        ]
+        
+        for collection_name in collection_names:
+            self.adapter.process_each_document(
+                collection_name=collection_name,
+                pipeline=[self.remove_designated_class_slot],
+            )
+
+    def remove_designated_class_slot(self, document:dict):
+        r"""
+        Removes the slot `designated_class` from collections that use it. 
+
+        >>> m = Migrator()
+        >>> m.add_type_slot_with_class_uri({'id': 123, 'designated_class': 'nmdc:OmicsProcessing'}) 
+        {'id': 123}
+        """
+
+        if "designated_class" in document:
+            document.pop('designated_class')
+            self.logger.info(f"Removing slot designated_class from doc {document['id']}")
+                
+        return document

--- a/nmdc_schema/migrators/migrator_from_X_to_unknown.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_unknown.py
@@ -33,7 +33,7 @@ class Migrator(MigratorBase):
         Removes the slot `designated_class` from collections that use it. 
 
         >>> m = Migrator()
-        >>> m.add_type_slot_with_class_uri({'id': 123, 'designated_class': 'nmdc:OmicsProcessing'}) 
+        >>> m.remove_designated_class_slot({'id': 123, 'designated_class': 'nmdc:OmicsProcessing'}) 
         {'id': 123}
         """
 

--- a/nmdc_schema/migrators/migrator_from_X_to_unknown.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_unknown.py
@@ -16,10 +16,10 @@ class Migrator(MigratorBase):
         """
 
         collection_names = [
-            "OmicsProcessing",
-            "Pooling",
-            "LibraryPreparation",
-            "Extraction"
+            "omics_processing_set",
+            "pooling_set",
+            "library_preparation_set",
+            "extraction_set"
         ]
         
         for collection_name in collection_names:


### PR DESCRIPTION
This migrator removes the `designated_class` slot from all collections that use it. 

This migrator was missed because there was no specific PR that mentioned it, but I believe it was probably part of adding the `type` slot requirement PR. I labeled this migrator as `unknown`. Let me know if you want to change it.

