### PR TITLE
update instrument migrator so `instrument_used` slot is multivalued

### DIFF
--- a/nmdc_schema/migrators/migrator_from_X_to_PR19_and_PR70.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR19_and_PR70.py
@@ -55,7 +55,7 @@ class Migrator(MigratorBase):
         >>> adapter = DictionaryAdapter(database=database)
         >>> m = Migrator(adapter=adapter)
         >>> m.transform_instrument_slot({'id': 'nmdc:omcp-123', 'instrument_name': '12T_FTICR_B'})
-        {'id': 'nmdc:omcp-123', 'instrument_used': 'nmdc:inst-456'}
+        {'id': 'nmdc:omcp-123', 'instrument_used': ['nmdc:inst-456']}
         """
 
         if "instrument_name" in omics_doc:

--- a/nmdc_schema/migrators/migrator_from_X_to_PR19_and_PR70.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR19_and_PR70.py
@@ -77,7 +77,7 @@ class Migrator(MigratorBase):
                     )
 
                     instrument_id = instrument.get("id")
-                    omics_doc["instrument_used"] = instrument_id
+                    omics_doc["instrument_used"] = [instrument_id]
                     del omics_doc["instrument_name"]
         
             else:


### PR DESCRIPTION
I missed that the `instrument_used` slot is multivalued. I updated the migrator that moves values from `instrument_name` to `instrument_used` to make the values a list.