### PR TITLE
Update `FailureWhereEnum`'s permissible values and implement migrator

### DIFF
--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -18,13 +18,13 @@ class Migrator(MigratorBase):
             self.adapter.process_each_document(collection_name=collection_name, pipeline=pipeline)
 
 
-    def standardize_failure_where_enum(self, read_qc_set: dict):
+    def standardize_failure_where_enum(self, read_qc_analysis: dict):
         r"""
         Transforms the values of the qc_failure_where slot to the new permissible values of the FailureWhereEnum.
         
         >>> m = Migrator()
-        >>> m.standardize_failure_where_enum({'id': 123, 'qc_failure_where': 'OmicsProcessing'})
-        {'id': 123, 'qc_failure_where': 'DataGeneration'}
+        >>> m.standardize_failure_where_enum({'id': 123, 'has_failure_categorization':{'qc_failure_where': 'OmicsProcessing'}})
+        {'id': 123, 'has_failure_categorization':{'qc_failure_where': 'DataGeneration'}})
         """
 
         failure_where_translation_dict = {
@@ -40,10 +40,11 @@ class Migrator(MigratorBase):
             "MetagenomeAnnotationActivity": "MetagenomeAnnotation",
         }
 
-        if 'qc_failure_where' in read_qc_set:
-            og_value = read_qc_set['qc_failure_where']
-            if og_value in failure_where_translation_dict.keys():
-                read_qc_set['qc_failure_where'] = failure_where_translation_dict[og_value]
-            else:
-                raise ValueError(f"Value {og_value} is not a valid value for the qc_failure_where slot.")
-        return read_qc_set
+        if 'has_failure_categorization' in read_qc_analysis.keys():
+            if 'qc_failure_where' in read_qc_analysis['has_failure_categorization'].keys():
+                og_value = read_qc_analysis['has_failure_categorization']['qc_failure_where']
+                if og_value in failure_where_translation_dict.keys():
+                    read_qc_analysis['has_failure_categorization']['qc_failure_where'] = failure_where_translation_dict[og_value]
+                else:
+                    raise ValueError(f"Value {og_value} is not a valid value for the qc_failure_where slot.")
+        return read_qc_analysis

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -23,8 +23,8 @@ class Migrator(MigratorBase):
         Transforms the values of the qc_failure_where slot to the new permissible values of the FailureWhereEnum.
         
         >>> m = Migrator()
-        >>> m.standardize_failure_where_enum({'id': 123, 'has_failure_categorization':{'qc_failure_where': 'OmicsProcessing'}})
-        {'id': 123, 'has_failure_categorization':{'qc_failure_where': 'DataGeneration'}})
+        >>> m.standardize_failure_where_enum({'id': 123, 'has_failure_categorization': {'qc_failure_where': 'OmicsProcessing'}})
+        {'id': 123, 'has_failure_categorization': {'qc_failure_where': 'DataGeneration'}})
         """
 
         failure_where_translation_dict = {

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -1,0 +1,49 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    """
+    Migrates data from X to PR129, namely changes the permissible values of the failure_where slot in the read_qc_analysis_set collection.
+    """
+    def upgrade(self):
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+
+        # Populate the "collection-to-transformers" map for this specific migration.
+        agenda = dict(
+            read_qc_analysis_activity_set=[self.standardize_failure_where_enum], 
+            # QUESTION: Should this be read_qc_analysis_activity_set or read_qc_analysis_set?  
+        )
+
+        for collection_name, pipeline in agenda.items():
+            self.adapter.process_each_document(collection_name=collection_name, pipeline=pipeline)
+
+
+    def standardize_failure_where_enum(self, read_qc_set: dict):
+        r"""
+        Transforms the values of the qc_failure_where slot to the new permissible values of the FailureWhereEnum.
+        
+        >>> m = Migrator()
+        >>> m.standardize_failure_where_enum({'id': 123, 'qc_failure_where': 'OmicsProcessing'})
+        {'id': 123, 'qc_failure_where': 'DataGeneration'}
+        """
+
+        failure_where_translation_dict = {
+            "OmicsProcessing": "DataGeneration",
+            "Pooling": "Pooling",
+            "Extraction": "Extraction",
+            "LibraryPreparation": "LibraryPreparation",
+            "MetagenomeAssembly": "MetagenomeAssembly",
+            "MetatranscriptomeActivity": "MetatranscriptomeAnalysis",
+            "MagsAnalysisActivity": "MagsAnalysis",
+            "ReadQcAnalysisActivity": "ReadQcAnalysis",
+            "ReadBasedTaxonomyAnalysisActivity": "ReadBasedTaxonomyAnalysis",
+            "MetagenomeAnnotationActivity": "MetagenomeAnnotation",
+        }
+
+        if 'qc_failure_where' in read_qc_set:
+            og_value = read_qc_set['qc_failure_where']
+            if og_value in failure_where_translation_dict.keys():
+                read_qc_set['qc_failure_where'] = failure_where_translation_dict[og_value]
+            else:
+                raise ValueError(f"Value {og_value} is not a valid value for the qc_failure_where slot.")
+        return read_qc_set

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -10,8 +10,7 @@ class Migrator(MigratorBase):
 
         # Populate the "collection-to-transformers" map for this specific migration.
         agenda = dict(
-            read_qc_analysis_activity_set=[self.standardize_failure_where_enum], 
-            # QUESTION: Should this be read_qc_analysis_activity_set or read_qc_analysis_set?  
+            read_qc_analysis_set=[self.standardize_failure_where_enum], 
         )
 
         for collection_name, pipeline in agenda.items():

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -3,7 +3,7 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 
 class Migrator(MigratorBase):
     """
-    Migrates data from X to PR126, namely changes the permissible values of the failure_where slot in the read_qc_analysis_set collection.
+    Migrates data from X to PR176, namely changes the permissible values of the failure_where slot in the read_qc_analysis_set collection.
 
     Should be run after migrator_from_X_to_PR2_and_PR24.py.
     """

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -24,7 +24,7 @@ class Migrator(MigratorBase):
         
         >>> m = Migrator()
         >>> m.standardize_failure_where_enum({'id': 123, 'has_failure_categorization': {'qc_failure_where': 'OmicsProcessing'}})
-        {'id': 123, 'has_failure_categorization': {'qc_failure_where': 'DataGeneration'}})
+        {'id': 123, 'has_failure_categorization': {'qc_failure_where': 'DataGeneration'}}
         """
 
         failure_where_translation_dict = {

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -3,7 +3,7 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 
 class Migrator(MigratorBase):
     """
-    Migrates data from X to PR129, namely changes the permissible values of the failure_where slot in the read_qc_analysis_set collection.
+    Migrates data from X to PR126, namely changes the permissible values of the failure_where slot in the read_qc_analysis_set collection.
     """
     def upgrade(self):
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -12,24 +12,25 @@ class Migrator(MigratorBase):
 
         # Populate the "collection-to-transformers" map for this specific migration.
         agenda = dict(
-            read_qc_analysis_set=[self.standardize_failure_where_enum], 
+            # We can assume that all the documents in the read_qc_analysis_set collection are of the type ReadQcAnalysisActivity, and any OmicsProcessing failures should be mapped to NucleotideSequencing
+            read_qc_analysis_set=[self.standardize_failure_where_enum_ns], 
         )
 
         for collection_name, pipeline in agenda.items():
             self.adapter.process_each_document(collection_name=collection_name, pipeline=pipeline)
 
 
-    def standardize_failure_where_enum(self, read_qc_analysis: dict):
+    def standardize_failure_where_enum_ns(self, read_qc_analysis: dict):
         r"""
-        Transforms the values of the qc_failure_where slot to the new permissible values of the FailureWhereEnum.
+        Transforms the values of the qc_failure_where slot to the new permissible values of the FailureWhereEnum, for sets related to NucleatideSequencing
         
         >>> m = Migrator()
-        >>> m.standardize_failure_where_enum({'id': 123, 'has_failure_categorization': {'qc_failure_where': 'OmicsProcessing'}})
-        {'id': 123, 'has_failure_categorization': {'qc_failure_where': 'DataGeneration'}}
+        >>> m.standardize_failure_where_enum_ns({'id': 123, 'has_failure_categorization': [{'qc_failure_where': 'OmicsProcessing'}]})
+        {'id': 123, 'has_failure_categorization': [{'qc_failure_where': 'NucleotideSequencing'}]}
         """
 
         failure_where_translation_dict = {
-            "OmicsProcessing": "DataGeneration",
+            "OmicsProcessing": "NucleotideSequencing",
             "Pooling": "Pooling",
             "Extraction": "Extraction",
             "LibraryPreparation": "LibraryPreparation",

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -4,6 +4,8 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 class Migrator(MigratorBase):
     """
     Migrates data from X to PR126, namely changes the permissible values of the failure_where slot in the read_qc_analysis_set collection.
+
+    Should be run after migrator_from_X_to_PR2_and_PR24.py.
     """
     def upgrade(self):
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -41,11 +41,12 @@ class Migrator(MigratorBase):
             "MetagenomeAnnotationActivity": "MetagenomeAnnotation",
         }
 
-        if 'has_failure_categorization' in read_qc_analysis.keys():
-            if 'qc_failure_where' in read_qc_analysis['has_failure_categorization'].keys():
-                og_value = read_qc_analysis['has_failure_categorization']['qc_failure_where']
-                if og_value in failure_where_translation_dict.keys():
-                    read_qc_analysis['has_failure_categorization']['qc_failure_where'] = failure_where_translation_dict[og_value]
+        if 'has_failure_categorization' in read_qc_analysis:
+            for failure_categorization in read_qc_analysis['has_failure_categorization']:
+                if 'qc_failure_where' in failure_categorization:
+                    og_value = failure_categorization.get('qc_failure_where')
+                    if og_value in failure_where_translation_dict:
+                        failure_categorization['qc_failure_where'] = failure_where_translation_dict.get(og_value)
                 else:
                     raise ValueError(f"Value {og_value} is not a valid value for the qc_failure_where slot.")
         return read_qc_analysis

--- a/src/data/invalid/Database-ReadQcAnalysisActivity-invalid.yaml
+++ b/src/data/invalid/Database-ReadQcAnalysisActivity-invalid.yaml
@@ -5,9 +5,9 @@ read_qc_analysis_activity_set:
     qc_status: pass
     has_failure_categorization:
       - qc_failure_what: malformed_data
-        qc_failure_where: ReadQcAnalysisActivity
+        qc_failure_where: ReadQcAnalysis
     qc_comment: Failure during call-stage to interleave fastq files
-    type: nmdc:ReadQcAnalysisActivity
+    type: nmdc:ReadQcAnalysis
     started_at_time: "2023-08-29T19:41:47.365957+00:00"
     ended_at_time:  "2023-08-30T13:26:02.892410+00:00"
     execution_resource: NERSC-Perlmutter

--- a/src/data/valid/Database-ReadQcAnalysisActivity-quality_fail.yaml
+++ b/src/data/valid/Database-ReadQcAnalysisActivity-quality_fail.yaml
@@ -7,7 +7,7 @@ read_qc_analysis_set:
     #since there can be multivalued and what/where should be paired we need this structure
     has_failure_categorization:
       - qc_failure_what: malformed_data
-        qc_failure_where: ReadQcAnalysisActivity
+        qc_failure_where: ReadQcAnalysis
         type: nmdc:FailureCategorization
     qc_comment: Failure during call-stage to interleave fastq files
     type: nmdc:ReadQcAnalysis
@@ -49,7 +49,7 @@ read_qc_analysis_set:
     qc_status: fail
     has_failure_categorization:
       - qc_failure_what: low_read_count
-        qc_failure_where: ReadQcAnalysisActivity
+        qc_failure_where: ReadQcAnalysis
         type: nmdc:FailureCategorization
     qc_comment: Most data removed for artifacts
     type: nmdc:ReadQcAnalysis

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -4349,7 +4349,7 @@ read_qc_analysis_set:
     has_failure_categorization:
       - type: nmdc:FailureCategorization
         qc_failure_what: malformed_data
-        qc_failure_where: ReadQcAnalysisActivity
+        qc_failure_where: ReadQcAnalysis
     ended_at_time: '2023-08-30T13:26:02.892410+00:00'
     execution_resource: NERSC-Perlmutter
     git_url: https://github.com/microbiomedata/ReadsQC
@@ -4391,7 +4391,7 @@ read_qc_analysis_set:
     has_failure_categorization:
       - type: nmdc:FailureCategorization
         qc_failure_what: low_read_count
-        qc_failure_where: ReadQcAnalysisActivity
+        qc_failure_where: ReadQcAnalysis
     ended_at_time: '2023-08-30T13:26:02.892410+00:00'
     execution_resource: NERSC-Perlmutter
     git_url: https://github.com/microbiomedata/ReadsQC

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -829,8 +829,8 @@ enums:
     comments:
       - At Chris' recommendation permissible values for this enumeration are the same as Class names.
     permissible_values:
-      OmicsProcessing:
-        description: A failure has occurred in omics processing, a lab process.
+      DataGeneration:
+        description: A failure has occurred in during data generation, a lab process.
       Pooling:
         description: A failure has occurred in pooling, a lab process.
       Extraction:
@@ -839,13 +839,13 @@ enums:
         description: A failure has occurred in library preparation, a lab process.
       MetagenomeAssembly:
         description: A failure has occurred in metagenome assembly, a workflow process.
-      MetatranscriptomeActivity:
+      MetatranscriptomeAnalysis:
         description: A failure has occurred in metatranscriptome analysis, a workflow process.
-      MagsAnalysisActivity:
+      MagsAnalysis:
         description: A failure has occurred in binning, a workflow process to generate metagenome-assembled genomes (MAGS).
-      ReadQcAnalysisActivity:
+      ReadQcAnalysis:
         description: A failure has occurred in read qc, a workflow process.
-      ReadBasedTaxonomyAnalysisActivity:
+      ReadBasedTaxonomyAnalysis:
         description: A failure has occurred in reads based taxonomy, a workflow process.
-      MetagenomeAnnotationActivity:
+      MetagenomeAnnotation:
         description: A failure has occurred in annotation, a workflow process.

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -829,8 +829,8 @@ enums:
     comments:
       - At Chris' recommendation permissible values for this enumeration are the same as Class names.
     permissible_values:
-      DataGeneration:
-        description: A failure has occurred during data generation, a lab process.
+      NucleotideSequencing:
+        description: A failure has occurred during nucleotide sequencing, a data generation process.
       Pooling:
         description: A failure has occurred in pooling, a lab process.
       Extraction:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -830,7 +830,7 @@ enums:
       - At Chris' recommendation permissible values for this enumeration are the same as Class names.
     permissible_values:
       DataGeneration:
-        description: A failure has occurred in during data generation, a lab process.
+        description: A failure has occurred during data generation, a lab process.
       Pooling:
         description: A failure has occurred in pooling, a lab process.
       Extraction:


### PR DESCRIPTION
Addresses https://github.com/microbiomedata/nmdc-schema/issues/1996.

This PR will update the permissible values on the `FailureWhereEnum` to reflect updated class names.  Example data (valid and invalid) are also updated.