### PR TITLE
Update structured_pattern in basic_classes

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -63,7 +63,7 @@ classes:
     slot_usage:
       id:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}{id_version}{id_locus}"
+          syntax: "{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$"
           interpolated: true
   PlannedProcess:
     abstract: true
@@ -358,7 +358,7 @@ classes:
       id:
         required: true
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:wfch-{id_shoulder}-{id_blade}{id_version}{id_locus}"
+          syntax: "{id_nmdc_prefix}:wfch-{id_shoulder}-{id_blade}$"
           interpolated: true
       analyte_category:
         required: true
@@ -438,7 +438,7 @@ classes:
       id:
         required: true
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:wf-{id_shoulder}-{id_blade}{id_version}{id_locus}"
+          syntax: "{id_nmdc_prefix}:wf-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
 slots:
   associated_studies:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -142,7 +142,7 @@ classes:
       id:
         required: true
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:chcpr-{id_shoulder}-{id_blade}{id_version}{id_locus}"
+          syntax: "{id_nmdc_prefix}:chcpr-{id_shoulder}-{id_blade}$"
           interpolated: true
 
   MetagenomeAnnotation:


### PR DESCRIPTION
Partially addresses: https://github.com/microbiomedata/nmdc-schema/issues/1988 .

Checking that the use of the `structured_pattern` slot is appropriately defined on all classes that were refactored.

When referencing a WorkflowExecution subclass it should be:
```
        structured_pattern:
          syntax: "{id_nmdc_prefix}:chcpr-{id_shoulder}-{id_blade}{id_version}$"
```

Otherwise it should be:
```
        structured_pattern:
          syntax: "{id_nmdc_prefix}:chcpr-{id_shoulder}-{id_blade}$"
```