### PR TITLE
Migrations: Update migrators to raise exceptions instead of logging errors

### DIFF
--- a/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
@@ -152,7 +152,7 @@ class Migrator(MigratorBase):
                 del study[slot_name]
             else:
                 self.logger.error(f'Field {slot_name} of Study {study["id"]} was not falsy. Skipped slot deletion.')
-                raise ValueError(f"Field {slot_name} of Study ({study["id"]}) is not empty.")
+                raise ValueError(f'Field {slot_name} of Study ({study["id"]}) is not empty.')
 
         # Remove associated_dois if empty (no dois were moved over and the slot is unnecessary)
         if not study['associated_dois']:

--- a/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
@@ -151,8 +151,8 @@ class Migrator(MigratorBase):
             if not study[slot_name]:
                 del study[slot_name]
             else:
-                self.logger.error(
-                    f'ERROR: Unexpected value in {slot_name} of {study["id"]} skipping slot deletion')
+                self.logger.error(f'Field {slot_name} of Study {study["id"]} was not falsy. Skipped slot deletion.')
+                raise ValueError(f"Field {slot_name} of Study ({study["id"]}) is not empty.")
 
         # Remove associated_dois if empty (no dois were moved over and the slot is unnecessary)
         if not study['associated_dois']:

--- a/nmdc_schema/migrators/migrator_from_X_to_PR176.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR176.py
@@ -44,10 +44,11 @@ class Migrator(MigratorBase):
 
         if 'has_failure_categorization' in read_qc_analysis:
             for failure_categorization in read_qc_analysis['has_failure_categorization']:
+                og_value = None  # ensure the variable is defined, since we use it in the error message
                 if 'qc_failure_where' in failure_categorization:
                     og_value = failure_categorization.get('qc_failure_where')
                     if og_value in failure_where_translation_dict:
                         failure_categorization['qc_failure_where'] = failure_where_translation_dict.get(og_value)
                 else:
-                    raise ValueError(f"Value {og_value} is not a valid value for the qc_failure_where slot.")
+                    raise ValueError(f"Invalid 'qc_failure_where' value: {og_value}")
         return read_qc_analysis

--- a/nmdc_schema/migrators/migrator_from_X_to_PR19_and_PR70.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR19_and_PR70.py
@@ -63,8 +63,9 @@ class Migrator(MigratorBase):
             
             instruments = load_yaml_asset("migrator_from_X_to_PR19_and_PR70/instrument_set.yaml")
             allowed_instrument_names = [instrument["name"] for instrument in instruments]
-            
-            matches = difflib.get_close_matches(existing_instrument_name, allowed_instrument_names, n=1, cutoff=0.25)
+
+            cutoff = 0.25
+            matches = difflib.get_close_matches(existing_instrument_name, allowed_instrument_names, n=1, cutoff=cutoff)
 
             if matches:
 
@@ -81,7 +82,10 @@ class Migrator(MigratorBase):
                     del omics_doc["instrument_name"]
         
             else:
-                self.logger.error(f"The instrument_name {omics_doc['id']} has a value of {omics_doc['instrument_name']}, but did not have any matches with the cutoff set at 0.25")
+                raise ValueError(f"The 'instrument_name' value ({existing_instrument_name}) "
+                                 f"on the OmicsProcessing document ({omics_doc['id']}) "
+                                 f"does not match any of the allowed instrument names "
+                                 f"(with a similarity score of at least {cutoff}).")
 
         return omics_doc
 

--- a/nmdc_schema/migrators/migrator_from_X_to_PR23.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR23.py
@@ -52,7 +52,8 @@ class Migrator(MigratorBase):
             # Get the permissible value, if any, that is most similar to the original value
             # and has a similarity score of at least 0.8 with respect to the original value.
             # Reference: https://docs.python.org/3/library/difflib.html#difflib.get_close_matches
-            matches = difflib.get_close_matches(workflow_resource_value, allowed_execution_resources, n=1, cutoff=0.8)
+            cutoff = 0.8
+            matches = difflib.get_close_matches(workflow_resource_value, allowed_execution_resources, n=1, cutoff=cutoff)
             
             if matches:
 
@@ -62,7 +63,10 @@ class Migrator(MigratorBase):
                     workflow_execution['execution_resource'] = matches[0]
 
             else:
-                self.logger.error(f"The workflow {workflow_id} has an execution_resource value of {workflow_resource_value}, but did not have any matches with the cutoff set at 0.8")
+                raise ValueError(f"The 'execution_resource' value ({workflow_resource_value}) "
+                                 f"on the WorkflowExecution document ({workflow_id}) "
+                                 f"does not match any of the allowed execution resources "
+                                 f"(with a similarity score of at least {cutoff}).")
 
         return workflow_execution
 

--- a/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR2_and_PR24.py
@@ -31,5 +31,4 @@ class Migrator(MigratorBase):
             try:
                 self.adapter.rename_collection(current_name=current_collection_name, new_name=new_collection_name)
             except KeyError:
-                print(f"Error: Collection '{current_collection_name}' not found in the adapter.")
-
+                raise KeyError(f"Error: Collection '{current_collection_name}' does not exist.")

--- a/nmdc_schema/migrators/migrator_from_X_to_PR3.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR3.py
@@ -38,7 +38,7 @@ class Migrator(MigratorBase):
         elif data_gen_doc["analyte_category"] in mass_spec:
             data_gen_doc["type"] = 'nmdc:MassSpectrometry'
         else:
-            self.logger.error(
-                    f"ERROR: analyte_category for {data_gen_doc['id']} is {data_gen_doc['analyte_category']}, which is not one of {nucleotide_seqs} or {mass_spec}")
+            raise ValueError(f"The 'analyte_category' value ({data_gen_doc['analyte_category']}) in document "
+                             f"({data_gen_doc['id']}) is not one of: {', '.join(nucleotide_seqs + mass_spec)}.")
 
         return data_gen_doc

--- a/nmdc_schema/migrators/migrator_from_X_to_PR31.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR31.py
@@ -78,7 +78,9 @@ class Migrator(MigratorBase):
                     self.logger.info(f"Workflow with id {doc['id']} has instrument: {doc['used']} matches OmicsProcessing doc instrument: {omics_processing_doc['instrument_name']} well enough")
                 doc.pop("used")
             else:
-                self.logger.error(f"Workflow doc {doc['id']} with instrument: {doc['used']} does not match {omics_processing_doc['instrument_name']}")
+                raise ValueError(f"The 'used' value ({doc['used']}) "
+                                 f"on the WorkflowExecution document ({doc['id']}) "
+                                 f"does not match the instrument name ({omics_processing_doc['instrument_name']}).")
         
         return doc
 

--- a/nmdc_schema/migrators/migrator_from_X_to_PR4.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR4.py
@@ -44,9 +44,10 @@ class Migrator(MigratorBase):
             # remove omics_type slot
             del omics_proc["omics_type"]
     
-        else: 
-            self.logger.error(f"omics type does not match any analyte categories for {omics_proc['id']}")
-        
+        else:
+            raise ValueError(f"The 'omics_type' value ({omics_type}) of document '{omics_proc['id']}' "
+                             f"does not match any 'analyte_category' values.")
+
         return omics_proc
 
     

--- a/nmdc_schema/migrators/migrator_from_X_to_PR9.py
+++ b/nmdc_schema/migrators/migrator_from_X_to_PR9.py
@@ -216,9 +216,9 @@ class Migrator(MigratorBase):
             if workflow_chain_doc["was_informed_by"] == omics_id:
                 del workflow_doc["was_informed_by"]
             else:
-                self.logger.error(
-                    f"WorkflowExecution doc with id {workflow_doc['id']} was_informed_by slot does not match"
-                    f"its workflow chain doc with id {workflow_chain_doc['id']} was_informed_by slot"
-                )
+                raise ValueError(f"The 'was_informed_by' value ({omics_id}) "
+                                 f"on the WorkflowExecutionActivity document ({workflow_doc['id']}) "
+                                 f"doesn't match the 'was_informed_by' value ({workflow_chain_doc['was_informed_by']}) "
+                                 f"on the corresponding WorkflowChain document ({workflow_chain_doc['id']}).")
 
         return workflow_doc


### PR DESCRIPTION
In this branch, I updated all existing migrators so that — instead of only logging an error message — they would raise an exception (and also maybe still log an error message). This will allow the "calling" code (e.g. migration notebooks) to "know" when an error has occurred.

In some cases, I also rephrased the error message and/or added variables' values to it (in an attempt to facilitate debugging).

Finally, in a couple of the migrators, I extracted the `cutoff` value into a variable so that I could include it in the error message (without "hard-coding" it there).

Fixes https://github.com/microbiomedata/nmdc-schema/issues/2004