### PR TITLE
Assert more pattern constraints on class-linking slots

### DIFF
--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -237,7 +237,7 @@ protocol_execution_set:
   - id: nmdc:pex-99-18sD2
     type: nmdc:ProtocolExecution
     has_input:
-      - nmdc:bsm-6
+      - nmdc:bsm-65-0002
     has_process_parts:
       - nmdc:extrp-71-r2pk
       - nmdc:filtpr-22-32G2BS

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -213,7 +213,7 @@ material_processing_set:
     sampled_portion:
       - supernatant
 storage_process_set:
-  - id: nmdc:matprc-99-zUCd5N
+  - id: nmdc:storpro-99-zUCd5N
     substances_used:
       - known_as: nmdc:chem-99-000003 # see src/data/valid/Database-chemical_entity_set-1.yaml
         type: nmdc:PortionOfSubstance

--- a/src/data/valid/ProtocolExecution-minimal.yaml
+++ b/src/data/valid/ProtocolExecution-minimal.yaml
@@ -1,7 +1,7 @@
 id: nmdc:pex-99-18sD2
 type: nmdc:ProtocolExecution
 has_input:
-  - nmdc:bsm-6
+  - nmdc:bsm-65-0002
 has_process_parts:
   - nmdc:extrp-71-r2pk
   - nmdc:filtpr-22-32G2BS

--- a/src/data/valid/ProtocolExecution-single_step.yaml
+++ b/src/data/valid/ProtocolExecution-single_step.yaml
@@ -1,7 +1,7 @@
 id: nmdc:pex-99-18sD2
 type: nmdc:ProtocolExecution
 has_input:
-  - nmdc:bsm-6
+  - nmdc:bsm-65-0002
 has_process_parts:
   - nmdc:extrp-71-r2pk
 protocol_execution_category: organic_matter_extraction

--- a/src/data/valid/StorageProcess-minimal.yaml
+++ b/src/data/valid/StorageProcess-minimal.yaml
@@ -1,5 +1,5 @@
 
-id: nmdc:matprc-99-zUCd5N
+id: nmdc:storpro-99-zUCd5N
 substances_used:
   - known_as: nmdc:chem-99-000003 # see src/data/valid/Database-chemical_entity_set-1.yaml
     type: nmdc:PortionOfSubstance

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -562,8 +562,6 @@ slots:
     multivalued: true
     description: >-
       An input to a process.
-    structured_pattern:
-      syntax: "XXXX"
 
   has_output:
     aliases:
@@ -571,8 +569,6 @@ slots:
     range: NamedThing
     multivalued: true
     description: An output from a process.
-    structured_pattern:
-      syntax: "XXXX"
 
   instrument_used:
     range: Instrument

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -562,6 +562,8 @@ slots:
     multivalued: true
     description: >-
       An input to a process.
+    structured_pattern:
+      syntax: "XXXX"
 
   has_output:
     aliases:
@@ -569,6 +571,8 @@ slots:
     range: NamedThing
     multivalued: true
     description: An output from a process.
+    structured_pattern:
+      syntax: "XXXX"
 
   instrument_used:
     range: Instrument

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -150,6 +150,18 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(dgms|omprc)-{id_shoulder}-{id_blade}$"
           interpolated: true
+      has_calibration:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:calib-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_chromatography_configuration:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:chrocon-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_mass_spectrometry_configuration:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:mscon-{id_shoulder}-{id_blade}$"
+          interpolated: true
     rules:
       - title: has_calibration_required_if_gc
         description: >-

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -426,7 +426,7 @@ classes:
           interpolated: true
       has_output:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
           interpolated: true
       has_process_parts:
         required: true

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -550,6 +550,19 @@ classes:
     slot_usage:
       substances_used:
         description: The substance(s) that a processed sample is stored in.
+      id:
+        required: true
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:storpro-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_input:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_output:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$"
+          interpolated: true
 
   ChromatographicSeparationProcess:
     class_uri: 'nmdc:ChromatographicSeparationProcess'

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -408,6 +408,20 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:pex-{id_shoulder}-{id_blade}$"
           interpolated: true
+      has_input:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_output:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_process_parts:
+        required: true
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:(extrp|filtpr|dispro|poolp|libprp|subspr|mixpro|chcpr|cspro)-{id_shoulder}-{id_blade}$"
+          interpolated: true
+        description: The MaterialProcessing steps that are discrete parts of the ProtocolExecution.
 
   SubSamplingProcess:
     class_uri: 'nmdc:SubSamplingProcess'


### PR DESCRIPTION
This PR adds pattern constraints to several classes through asserting `slot_usage` and updates associated tests to pass these tests (previously using non-passing IDs).

Addresses https://github.com/microbiomedata/nmdc-schema/issues/2061.

1) `ProtocolExecution` now has pattern constraints for `has_input`, `has_output`, and `has_process_parts` slots
2) `StorageProcess` now has pattern constraints for `id` slot.  (I had missed this class during https://github.com/microbiomedata/berkeley-schema-fy24/pull/177)
3) `MassSpectrometry` now has pattern constraints for `has_calibration`, `has_chromatography_configuration`, and `has_mass_spectrometry_configuration` slots.  

No migration needed and no anticipated effects on refactoring process, this is just shoring up specificity in the model to prevent future id issues.