### PR TITLE
Update migrators to use correct collection name (`mags_set`)

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_PR104_to_PR195.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_PR104_to_PR195.py
@@ -38,7 +38,7 @@ class Migrator(MigratorBase):
             "metatranscriptome_assembly_set",
             "metatranscriptome_annotation_set",
             "metatranscriptome_analysis_set",
-            "mags_analysis_set",
+            "mags_set",
             "metagenome_sequencing_set",
             "read_qc_analysis_set",
             "read_based_taxonomy_analysis_set",

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_X_to_PR104.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_X_to_PR104.py
@@ -25,7 +25,7 @@ class Migrator(MigratorBase):
         "metatranscriptome_assembly_set",
         "metatranscriptome_annotation_set",
         "metatranscriptome_analysis_set",
-        "mags_analysis_set",
+        "mags_set",
         "metagenome_sequencing_set",
         "read_qc_analysis_set",
         "read_based_taxonomy_analysis_set",


### PR DESCRIPTION
In this branch, I updated two migrators so they no longer refer to a collection by an incorrect name (i.e. `mags_analysis_set`), and instead refer to it by its correct name (i.e. `mags_set`).

The correct name of the collection is `mags_set`. That name was given to the collection via migrator `nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_X_to_PR2_and_PR24.py`, which is run [_before_](https://github.com/microbiomedata/berkeley-schema-fy24/blob/09f0468fd884d73e021f36d4fa8e50dfecefb1b6/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/__init__.py#L69-L86) the two migrators being updated in this PR branch.

On a side note, the collection's original name was `mags_activity_set`. I don't know where the incorrect name, `mags_analysis_set`, came from (perhaps it was the result of a copy/paste error or an invalid assumption about the collection names used for a given [class name](https://microbiomedata.github.io/berkeley-schema-fy24/MagsAnalysis/)).