### PR TITLE
Deprecate `EnvironmentalMaterialTerm`, `Pathway`

### DIFF
--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -72,7 +72,7 @@ classes:
     todos:
       - decide if this should be used for product naming (Duncan, 2021-04-02)
       - Retaining this even after removing Reaction. See todos on the Pathway and OrthologyGroup subclasses.
-    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used. 2024-07-10 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   Pathway:
     class_uri: nmdc:Pathway
@@ -91,7 +91,7 @@ classes:
     todos:
       - If we reverted to including Reaction in the schema, then a Reaction would be a reasonable part_of a Pathway
       - is Pathway instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
-    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used. 2024-07-10 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   OrthologyGroup:
     class_uri: nmdc:OrthologyGroup
@@ -112,7 +112,7 @@ classes:
       - KEGG.ORTHOLOGY prefix is used for KO numbers
     todos:
       - is OrthologyGroup instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
-    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used. 2024-07-10 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   FunctionalAnnotation:
     class_uri: nmdc:FunctionalAnnotation

--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -72,7 +72,6 @@ classes:
     todos:
       - decide if this should be used for product naming (Duncan, 2021-04-02)
       - Retaining this even after removing Reaction. See todos on the Pathway and OrthologyGroup subclasses.
-    deprecated: "not used. 2024-07-10 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   Pathway:
     class_uri: nmdc:Pathway
@@ -112,7 +111,6 @@ classes:
       - KEGG.ORTHOLOGY prefix is used for KO numbers
     todos:
       - is OrthologyGroup instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
-    deprecated: "not used. 2024-07-10 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   FunctionalAnnotation:
     class_uri: nmdc:FunctionalAnnotation

--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -72,7 +72,7 @@ classes:
     todos:
       - decide if this should be used for product naming (Duncan, 2021-04-02)
       - Retaining this even after removing Reaction. See todos on the Pathway and OrthologyGroup subclasses.
-    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   Pathway:
     class_uri: nmdc:Pathway
@@ -91,7 +91,7 @@ classes:
     todos:
       - If we reverted to including Reaction in the schema, then a Reaction would be a reasonable part_of a Pathway
       - is Pathway instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
-    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   OrthologyGroup:
     class_uri: nmdc:OrthologyGroup
@@ -112,7 +112,7 @@ classes:
       - KEGG.ORTHOLOGY prefix is used for KO numbers
     todos:
       - is OrthologyGroup instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
-    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   FunctionalAnnotation:
     class_uri: nmdc:FunctionalAnnotation

--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -72,6 +72,7 @@ classes:
     todos:
       - decide if this should be used for product naming (Duncan, 2021-04-02)
       - Retaining this even after removing Reaction. See todos on the Pathway and OrthologyGroup subclasses.
+    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   Pathway:
     class_uri: nmdc:Pathway
@@ -90,6 +91,7 @@ classes:
     todos:
       - If we reverted to including Reaction in the schema, then a Reaction would be a reasonable part_of a Pathway
       - is Pathway instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
+    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   OrthologyGroup:
     class_uri: nmdc:OrthologyGroup
@@ -110,6 +112,7 @@ classes:
       - KEGG.ORTHOLOGY prefix is used for KO numbers
     todos:
       - is OrthologyGroup instantiated in an MongoDB collection? Aren't Pathways searchable in the Data Portal?
+    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   FunctionalAnnotation:
     class_uri: nmdc:FunctionalAnnotation

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1267,7 +1267,7 @@ classes:
   EnvironmentalMaterialTerm:
     is_a: OntologyClass
     class_uri: 'nmdc:EnvironmentalMaterialTerm'
-    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used. 2024-07-10 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   MagBin:
     class_uri: nmdc:MagBin

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1267,6 +1267,7 @@ classes:
   EnvironmentalMaterialTerm:
     is_a: OntologyClass
     class_uri: 'nmdc:EnvironmentalMaterialTerm'
+    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   MagBin:
     class_uri: nmdc:MagBin

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1267,7 +1267,7 @@ classes:
   EnvironmentalMaterialTerm:
     is_a: OntologyClass
     class_uri: 'nmdc:EnvironmentalMaterialTerm'
-    deprecated: "not used or planned to be used. https://github.com/microbiomedata/nmdc-schema/issues/1881"
+    deprecated: "not used or planned to be used. 2024-07-09 https://github.com/microbiomedata/nmdc-schema/issues/1881"
 
   MagBin:
     class_uri: nmdc:MagBin


### PR DESCRIPTION
See https://github.com/microbiomedata/nmdc-schema/issues/1881

This PR is the first step in deprecating `EnvironmentalMaterialTerm`, `FunctionalAnnotationTerm` + children. It adds a `deprecated:` string to each class definition. This PR will need to be reviewed to see if/when it can be merged in during the Berkeley schema rollout, or if we need to wait.