### PR TITLE
Typecode fixes on IDs for `ChromatographyConfiguration`, `StorageProcess`, and `MassSpectrometryConfiguration` class ids

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,9 +109,9 @@ Core developers should read the material on the [LinkML site](https://linkml.io/
     - Follow the naming conventions of the parent class
     - Descriptions of child classes may reference parent classes in a genus-differentia definition structure (e.g. "A workflow execution activity that...")
     - Inheritance should be monotonic: `slot_usage` should refine rather than override
-- ID patterning
-    - New classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
-    - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit range to the expecting linked class
+- ID patterning and checks
+    - ID patterns for new classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
+    - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit range to only instances of the expecting linked class (i.e. `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"`)
 
 ### Testing Changes Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,9 @@ Core developers should read the material on the [LinkML site](https://linkml.io/
     - Follow the naming conventions of the parent class
     - Descriptions of child classes may reference parent classes in a genus-differentia definition structure (e.g. "A workflow execution activity that...")
     - Inheritance should be monotonic: `slot_usage` should refine rather than override
+- ID patterning
+    - New classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
+    - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit range to the expecting linked class
 
 ### Testing Changes Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Core developers should read the material on the [LinkML site](https://linkml.io/
 - ID patterning and checks
     - ID patterns for new classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
     - In the _rare_ case that NMCD records must support legacy typecodes, typecodes can be declared on new classes with multiple typecodes (i.e. `syntax: "{id_nmdc_prefix}:(dgns|omprc)-{id_shoulder}-{id_blade}$"`). In this case, the _first_ typecode is the one the NMDC Runtime's [minter](https://github.com/microbiomedata/nmdc-runtime/tree/main/nmdc_runtime/minter) will use when generating new ids for the class.
-    - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit to only instances of the expecting linked class (i.e. `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"` on the `structured_pattern` to ensure that only records with ids associated with the typecode "chrcon" can fill that slot)
+    - Class-linking slots (i.e. `has_input`) should have a `slot_usage` declared that limits the slot's values to ids of instances of _only_ the specific classes you want to allow the slot to link to (e.g. using `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"` on the `structured_pattern` will make it so only ids having the typecode `chrcon` can fill that slot)
 
 ### Testing Changes Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Core developers should read the material on the [LinkML site](https://linkml.io/
     - Inheritance should be monotonic: `slot_usage` should refine rather than override
 - ID patterning and checks
     - ID patterns for new classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
-    - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit range to only instances of the expecting linked class (i.e. `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"`)
+    - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit to only instances of the expecting linked class (i.e. `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"` on the `structured_pattern` to ensure that only records with ids associated with the typecode "chrcon" can fill that slot)
 
 ### Testing Changes Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Core developers should read the material on the [LinkML site](https://linkml.io/
     - Inheritance should be monotonic: `slot_usage` should refine rather than override
 - ID patterning and checks
     - ID patterns for new classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
-    - In the _rare_ case that NMCD records must support legacy typecodes, typecodes can be declared on new classes with multiple typecodes (i.e. `syntax: "{id_nmdc_prefix}:(dgns|omprc)-{id_shoulder}-{id_blade}$"`). In this case, the _first_ typecode is the currently preferred and used to generate new ids for the class.
+    - In the _rare_ case that NMCD records must support legacy typecodes, typecodes can be declared on new classes with multiple typecodes (i.e. `syntax: "{id_nmdc_prefix}:(dgns|omprc)-{id_shoulder}-{id_blade}$"`). In this case, the _first_ typecode is the one the NMDC Runtime's [minter](https://github.com/microbiomedata/nmdc-runtime/tree/main/nmdc_runtime/minter) will use when generating new ids for the class.
     - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit to only instances of the expecting linked class (i.e. `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"` on the `structured_pattern` to ensure that only records with ids associated with the typecode "chrcon" can fill that slot)
 
 ### Testing Changes Locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ Core developers should read the material on the [LinkML site](https://linkml.io/
     - Inheritance should be monotonic: `slot_usage` should refine rather than override
 - ID patterning and checks
     - ID patterns for new classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
+    - In the _rare_ case that NMCD records must support legacy typecodes, typecodes can be declared on new classes with multiple typecodes (i.e. `syntax: "{id_nmdc_prefix}:(dgns|omprc)-{id_shoulder}-{id_blade}$"`). In this case, the _first_ typecode is preferred and used to generate new ids for the class.
     - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit to only instances of the expecting linked class (i.e. `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"` on the `structured_pattern` to ensure that only records with ids associated with the typecode "chrcon" can fill that slot)
 
 ### Testing Changes Locally

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Core developers should read the material on the [LinkML site](https://linkml.io/
     - Inheritance should be monotonic: `slot_usage` should refine rather than override
 - ID patterning and checks
     - ID patterns for new classes should follow conventions found [here](https://microbiomedata.github.io/nmdc-schema/identifiers/)
-    - In the _rare_ case that NMCD records must support legacy typecodes, typecodes can be declared on new classes with multiple typecodes (i.e. `syntax: "{id_nmdc_prefix}:(dgns|omprc)-{id_shoulder}-{id_blade}$"`). In this case, the _first_ typecode is preferred and used to generate new ids for the class.
+    - In the _rare_ case that NMCD records must support legacy typecodes, typecodes can be declared on new classes with multiple typecodes (i.e. `syntax: "{id_nmdc_prefix}:(dgns|omprc)-{id_shoulder}-{id_blade}$"`). In this case, the _first_ typecode is the currently preferred and used to generate new ids for the class.
     - Class-linking slots (i.e. `has_input`) should have slot_usage declared that limit to only instances of the expecting linked class (i.e. `syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"` on the `structured_pattern` to ensure that only records with ids associated with the typecode "chrcon" can fill that slot)
 
 ### Testing Changes Locally

--- a/src/data/valid/ChromatographyConfiguration-GC.yaml
+++ b/src/data/valid/ChromatographyConfiguration-GC.yaml
@@ -1,4 +1,4 @@
-id: nmdc:chrocon-99-oW43DzG0
+id: nmdc:chrcon-99-oW43DzG0
 type: nmdc:ChromatographyConfiguration
 name: "EMSL GC method for small molecules"
 description: "EMSL's GC method for small molecule analysis"

--- a/src/data/valid/ChromatographyConfiguration-LC.yaml
+++ b/src/data/valid/ChromatographyConfiguration-LC.yaml
@@ -1,4 +1,4 @@
-id: nmdc:chrocon-99-oW43DzG0
+id: nmdc:chrcon-99-oW43DzG0
 type: nmdc:ChromatographyConfiguration
 name: "EMSL HILIC method for small molecules"
 description: "EMSL's hydrophilic interaction liquid chromatography method for small molecules"

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -210,7 +210,7 @@ material_processing_set:
     sampled_portion:
       - supernatant
 storage_process_set:
-  - id: nmdc:storpro-99-zUCd5N
+  - id: nmdc:storpr-99-zUCd5N
     substances_used:
       - known_as: nmdc:chem-99-000003 # see src/data/valid/Database-chemical_entity_set-1.yaml
         type: nmdc:PortionOfSubstance
@@ -3907,7 +3907,7 @@ data_generation_set:
     type: nmdc:MassSpectrometry
     eluent_introduction_category: liquid_chromatography
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
-    has_chromatography_configuration: nmdc:chrocon-99-oW43DzG0
+    has_chromatography_configuration: nmdc:chrcon-99-oW43DzG0
     analyte_category: lipidome
     has_input:
       - nmdc:procsm-99-0wxpzf08
@@ -3924,7 +3924,7 @@ data_generation_set:
     eluent_introduction_category: liquid_chromatography
     analyte_category: lipidome
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
-    has_chromatography_configuration: nmdc:chrocon-99-oW43DzG0
+    has_chromatography_configuration: nmdc:chrcon-99-oW43DzG0
     has_input:
       - nmdc:procsm-99-0wxpzf08
     start_date: 31-OCT-14 01.00.00.000000000 AM
@@ -4779,7 +4779,7 @@ configuration_set:
       - ion_trap
     ionization_source: electrospray_ionization
     polarity_mode: negative
-  - id: nmdc:chrocon-99-oW43DzG0
+  - id: nmdc:chrcon-99-oW43DzG0
     name: EMSL LC method for non-polar metabolites
     description: LC method for non-polar metabolites used by EMSL
     type: nmdc:ChromatographyConfiguration

--- a/src/data/valid/Database-mass-spectrometry.yaml
+++ b/src/data/valid/Database-mass-spectrometry.yaml
@@ -3,7 +3,7 @@ data_generation_set:
     type: nmdc:MassSpectrometry
     eluent_introduction_category: liquid_chromatography
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
-    has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
+    has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
     analyte_category: lipidome
     has_input:
       - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
@@ -20,7 +20,7 @@ data_generation_set:
     eluent_introduction_category: liquid_chromatography
     analyte_category: lipidome
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
-    has_chromatography_configuration: nmdc:chrocon-11-oW43DzG0
+    has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
     has_input:
       - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
     start_date: 31-OCT-14 01.00.00.000000000 AM
@@ -89,7 +89,7 @@ configuration_set:
       - ion_trap
     ionization_source: electrospray_ionization
     polarity_mode: negative
-  - id: nmdc:chrocon-11-oW43DzG0
+  - id: nmdc:chrcon-11-oW43DzG0
     name: EMSL LC method for non-polar metabolites
     description: LC method for non-polar metabolites used by EMSL
     type: nmdc:ChromatographyConfiguration

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -6,7 +6,7 @@ data_generation_set:
     has_output:
       - nmdc:dobj-11-9n9n9n                                     #defined below
     has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG0 #defined below
-    has_chromatography_configuration: nmdc:chrocon-99-oW43DzG1  #defined below
+    has_chromatography_configuration: nmdc:chrcon-99-oW43DzG1   #defined below
     eluent_introduction_category: gas_chromatography
     has_calibration: nmdc:calib-99-zUCd5Q                       #defined below
     analyte_category: metabolome
@@ -21,7 +21,7 @@ calibration_set:
     calibration_target: retention_index
     calibration_standard: fames
 configuration_set:
-  - id: nmdc:chrocon-99-oW43DzG1
+  - id: nmdc:chrcon-99-oW43DzG1
     type: nmdc:ChromatographyConfiguration
     name: "EMSL GC method for small molecules"
     description: "EMSL's Gas Chromatography method for small molecules"

--- a/src/data/valid/StorageProcess-minimal.yaml
+++ b/src/data/valid/StorageProcess-minimal.yaml
@@ -1,5 +1,5 @@
 
-id: nmdc:storpro-99-zUCd5N
+id: nmdc:storpr-99-zUCd5N
 substances_used:
   - known_as: nmdc:chem-99-000003 # see src/data/valid/Database-chemical_entity_set-1.yaml
     type: nmdc:PortionOfSubstance

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -216,7 +216,7 @@ classes:
         required: true
       id:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:(mscon)-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:mscon-{id_shoulder}-{id_blade}$"
           interpolated: true
   
   ChromatographyConfiguration:
@@ -237,7 +237,7 @@ classes:
         required: true
       id:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:(chrocon)-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:chrocon-{id_shoulder}-{id_blade}$"
           interpolated: true
 
   FunctionalAnnotationAggMember:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -156,7 +156,7 @@ classes:
           interpolated: true
       has_chromatography_configuration:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:chrocon-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"
           interpolated: true
       has_mass_spectrometry_configuration:
         structured_pattern:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -237,7 +237,7 @@ classes:
         required: true
       id:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:chrocon-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"
           interpolated: true
 
   FunctionalAnnotationAggMember:
@@ -578,7 +578,7 @@ classes:
       id:
         required: true
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:storpro-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:storpr-{id_shoulder}-{id_blade}$"
           interpolated: true
       has_input:
         structured_pattern:


### PR DESCRIPTION
# PR Information

## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Documentation
     
## Description
This PR aims to 

1. Shorten id typecodes to adhere to nmdc standards for two berkeley-schema specific classes (aka, no data in mongo for these).  
        - `ChromatographyConfiguration` typecode changed from `chrocon` to `chrcon`
        - `StorageProcess` typecode changed from `storpro` to `storpr`
All tests and references to these old typecodes 
2. Update CONTRIBUTING guide to reflect the typecode guidelines 
3. Remove extraneous parentheses for ids on definition of `MassSpectrometryConfiguration` and  `ChromatographyConfiguration`.

## Related Issues
- Addresses the schema-relevant portion of: https://github.com/microbiomedata/nmdc-schema/issues/2122 .  The other aspect of that issue is documented here: https://github.com/microbiomedata/nmdc-runtime/issues/592

## Did you add/update any tests?

- [x] Yes _I updated the example data that is tested_

## Could this schema change make it so any valid data becomes invalid?
- [x] Yes _(A migrator is required)_
_there are no existing data in mongo that are part of these classes_ (we discovered these issues when trying to mint IDs in order to load these classes).  @eecavanna are you OK with no migrator for this change? I understand that this is not best practice, but making a migrator for theoretical records with ids that could not have been minted seems a bit....unnecessary.

## If you answered "Yes", does this PR branch include that migrator?
- [x] No, but we've decided it it unnecessary, see conversation below 

## Does this PR have any downstream implications?
- [x] No