### PR TITLE
Update migrator to treat `metatranscriptome_expression_analysis_set` as child of `workflow_execution_set`

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_16.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_16.py
@@ -38,6 +38,7 @@ class Migrator(MigratorBase):
             "metatranscriptome_assembly_set",
             "metatranscriptome_annotation_set",
             "metatranscriptome_analysis_set",
+            "metatranscriptome_expression_analysis_set",  # included in order to accommodate: https://github.com/microbiomedata/nmdc-schema/pull/2117
             "mags_set",
             "metagenome_sequencing_set",
             "read_qc_analysis_set",
@@ -59,6 +60,7 @@ class Migrator(MigratorBase):
         >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
         >>> database = {'material_processing_set': [{'id': 'mp'}],
         ...             'pooling_set': [{'id': 'p'}],
+        ...             'metatranscriptome_expression_analysis_set': [{'id': 'ma1'}],
         ...             'nom_analysis_set': [{'id': 'na1'}, {'id': 'na2'}, {'id': 'na3'}]}
         >>> m = Migrator(adapter=DictionaryAdapter(database=database))
         >>> m.upgrade()
@@ -67,7 +69,9 @@ class Migrator(MigratorBase):
         >>> 'pooling_set' in database  # ensure migrator deletes "child" collection
         False
         >>> len(database['workflow_execution_set'])  # ensure migrator creates "parent" collection (if nonexistent)
-        3
+        4
+        >>> 'metatranscriptome_expression_analysis_set' in database
+        False
         >>> 'nom_analysis_set' in database
         False
         """


### PR DESCRIPTION
# PR Information

## What type of PR is this? (check all applicable)

- [x] Bug Fix - in the sense that this migrator would have "missed" a collection that was      

## Description

In this branch, I updated a migrator so that it would treat a collection named `metatranscriptome_expression_analysis_set` (introduced into the `nmdc-schema` via PR https://github.com/microbiomedata/nmdc-schema/pull/2117) as a "child collection" of the `workflow_execution_set` collection.

## Related Issues

> All PRs should relate to or fix an issue(s). Please identify the issue(s) below.

- Related Issue(s): https://github.com/microbiomedata/nmdc-schema/pull/2117
- Fixes: https://github.com/microbiomedata/nmdc-schema/issues/2124

## Did you add/update any tests?

- [x] Yes

I updated doctests.

## Could this schema change make it so any valid data becomes invalid?

- [x] No

It is not a schema change.

## Does this PR have any downstream implications?

> Examples: any change here that requires a change to workflows, workflow automation, the Mongo-to-Postgres ingest process, Jupyter notebooks, the Runtime, etc.

- [x] No

The only consumer of this is the migration notebook, and this change will be transparent to the notebook.