### PR TITLE
Remove `ChemicalEntity` as range for `metabolite_identified` slot

### DIFF
--- a/src/data/invalid/ChemicalEntity-1.yaml
+++ b/src/data/invalid/ChemicalEntity-1.yaml
@@ -1,0 +1,13 @@
+# this example is invalid because it is not a valid typecode for a ChemicalEntity
+chemical_formula: C6H12O6
+inchi: "1S/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2/t2-,3-,4+,5-,6?/m1/s1" # https://en.wikipedia.org/wiki/Glucose
+inchi_key: "WQZGKKKJIJFFOK-GASJEMHNSA-N"
+smiles:
+  - "OC[C@H]1OC(O)[C@H](O)[C@@H](O)[C@@H]1O"
+  - "C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O"
+id: nmdc:notchem-99-000001 # made up typecode.
+name: "glucose"
+description: "generally considered the most abundant monosaccharide in nature"
+alternative_identifiers:
+  - wd:Q37525 # https://www.wikidata.org/entity/Q37525
+type: nmdc:ChemicalEntity

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1673,7 +1673,6 @@ slots:
 
   metabolite_identified:
     description: the specific metabolite identifier
-    range: ChemicalEntity
 
   all_proteins:
     description: the list of protein identifiers that are associated with the peptide sequence

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1346,8 +1346,6 @@ classes:
     description: >-
       An atom or molecule that can be represented with a chemical formula. Include lipids, glycans, natural products, drugs.
       There may be different terms for distinct acid-base forms, protonation states
-    comments:
-      - As with the parent OntologyClass, we will not assign an nmdc id pattern or typecode to this class.
     slots:
       - alternative_names
       - chemical_formula

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1238,6 +1238,12 @@ classes:
       - substance_role
       - type
       - volume
+    slot_usage:
+      known_as:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:chem-{id_shoulder}-{id_blade}$"
+          interpolated: true
+
 
   ProcessedSample:
     class_uri: nmdc:ProcessedSample
@@ -1592,6 +1598,7 @@ slots:
     inlined_as_list: true
 
   known_as:
+    description: An identifier of a ChemicalEntity.
     range: ChemicalEntity
 
   substance_role:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1361,15 +1361,6 @@ classes:
 
     see_also:
       - https://bioconductor.org/packages/devel/data/annotation/vignettes/metaboliteIDmapping/inst/doc/metaboliteIDmapping.html
-    id_prefixes:
-      - cas
-      - CHEBI
-      - CHEMBL.COMPOUND
-      - DRUGBANK
-      - HMDB
-      - KEGG.COMPOUND
-      - MESH
-      - PUBCHEM.COMPOUND
     exact_mappings:
       - biolink:ChemicalSubstance
 

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1354,6 +1354,12 @@ classes:
       - inchi
       - inchi_key
       - smiles
+    slot_usage:
+      id:
+        required: true
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:chem-{id_shoulder}-{id_blade}$"
+          interpolated: true
 
     see_also:
       - https://bioconductor.org/packages/devel/data/annotation/vignettes/metaboliteIDmapping/inst/doc/metaboliteIDmapping.html


### PR DESCRIPTION
## Description

This PR will:
1) Remove `ChemicalEntity` as range for metabolite_identified slot.
    - closes microbiomedata/nmdc-schema/issues/2153, as discussed here: microbiomedata/nmdc-schema/discussions/2151
2) Add `structured_pattern` constraint and requirement on `id` slot for `ChemicalEntity` class and invalid test for bad typecode
3) Add `structured_pattern` constraint on `known_as` slot to match its range of `ChemicalEntity` and adds description for `known_as` slot 
    - closes https://github.com/microbiomedata/nmdc-schema/issues/2121
4) Remove id_prefixes from `ChemicalEntity` class - @sierra-moxon  or @turbomam  please confirm this is appropriate as this is my first exposure to that slot.

-------
## Reviewers

to review: @mslarae13, @turbomam, @sierra-moxon

to tag for schema freeze purposes: @aclum, @mbthornton-lbl, @corilo, @SamuelPurvine, @naglepuff, @sujaypatil96, @brynnz22, @eecavanna 

# PR Information

## What type of PR is this? (check all applicable)
- [x] Documentation
- [x] Schema change: Cleanup and preparation
  - updated the description of a `slot`
  - updated the range of a `slot` (made it wide open!)
     
## Did you add/update any tests?
- [x] Yes

## Could this schema change make it so any valid data becomes invalid?

- [x] No (no valid data in mongo for `ChemicalEntity` because there is no `chemical_entity_set` until the berkeley schema, therefore no way for there to be `ChemicalEntity`s in mongo)

## Does this PR have any downstream implications?
- [x] No
