### PR TITLE
Refine the list of `Instrument`s a migrator can map an instrument name to

### DIFF
--- a/nmdc_schema/migrators/assets/migrator_from_10_2_0_to_11_0_0_part_08/instrument_set.yaml
+++ b/nmdc_schema/migrators/assets/migrator_from_10_2_0_to_11_0_0_part_08/instrument_set.yaml
@@ -33,14 +33,9 @@
   name: Illumina HiSeq 2500
   vendor: illumina
   type: nmdc:Instrument
-- id: nmdc:inst-14-f3fa7010
-  model: hiseq_2500
-  name: Illumina HiSeq 2500-1TB
-  vendor: illumina
-  type: nmdc:Instrument
 - id: nmdc:inst-14-xz5tb342
   model: nextseq_550
-  name: Illumina NextSeq550
+  name: Illumina NextSeq 550
   vendor: illumina
   type: nmdc:Instrument
 - id: nmdc:inst-14-xx07be40
@@ -49,13 +44,8 @@
   vendor: illumina
   type: nmdc:Instrument
 - id: nmdc:inst-14-mr4r2w09
-  model: novaseq
-  name: Illumina NovaSeq S4
-  vendor: illumina
-  type: nmdc:Instrument
-- id: nmdc:inst-14-8z926823
-  model: novaseq
-  name: NovaSeq SP
+  model: novaseq_6000
+  name: Illumina NovaSeq 6000
   vendor: illumina
   type: nmdc:Instrument
 - id: nmdc:inst-14-kw06tx33

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
@@ -57,18 +57,59 @@ class Migrator(MigratorBase):
 
         >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
         >>>
-        >>> database = {
-        ...     'instrument_set': [
-        ...        {'id': 'nmdc:inst-456', 'name': '12T FT-ICR MS', 'model':'solarix_12T', 'vendor':'bruker', 'type':'nmdc:Instrument'},
-        ...        {'id': 'nmdc:inst-101', 'name': 'Illumina NovaSeq 6000', 'model':'my model', 'vendor':'my vendor', 'type':'nmdc:Instrument'},
-        ...     ]
-        ... } 
+        >>> # Seed the database with instruments representative of those described in `instrument_set.yaml`.
+        >>> #
+        >>> # Note: These "input" names and the corresponding "output" names below were reviewed by a stakeholder at:
+        >>> #       https://github.com/microbiomedata/berkeley-schema-fy24/pull/247#issuecomment-2342009832
+        >>> #
+        >>> database = dict(instrument_set=[])
+        >>> for (id, name) in [
+        ...     ('nmdc:inst-14-tjtq1d92', '12T FT-ICR MS'),
+        ...     ('nmdc:inst-14-dzs60b60', '15T FT-ICR MS'),
+        ...     ('nmdc:inst-14-nstrhv39', '21T FT-ICR MS'),
+        ...     ('nmdc:inst-14-mwrrj632', '7T FT-ICR MS'),
+        ...     ('nmdc:inst-14-fas8ny90', 'GC-MS'),
+        ...     ('nmdc:inst-14-79zxap02', 'Illumina HiSeq'),
+        ...     ('nmdc:inst-14-nn4b6k72', 'Illumina HiSeq 2500'),
+        ...     ('nmdc:inst-14-xz5tb342', 'Illumina NextSeq 550'),
+        ...     ('nmdc:inst-14-xx07be40', 'Illumina NovaSeq'),
+        ...     ('nmdc:inst-14-mr4r2w09', 'Illumina NovaSeq 6000'),
+        ...     ('nmdc:inst-14-kw06tx33', 'QExactHF03'),
+        ...     ('nmdc:inst-14-e32bpm65', 'QExactP02'),
+        ...     ('nmdc:inst-14-njkx0e66', 'VOrbiETD04'),
+        ... ]:
+        ...     instrument_doc = dict(id=id, name=name, model='', vendor='', type='nmdc:Instrument')
+        ...     database['instrument_set'].append(instrument_doc)
         >>> adapter = DictionaryAdapter(database=database)
         >>> m = Migrator(adapter=adapter)
-        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-123', 'instrument_name': '12T_FTICR_B'})
-        {'id': 'nmdc:omcp-123', 'instrument_used': ['nmdc:inst-456']}
-        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'NovaSeq X'})
-        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-101']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': '12T_FTICR_B'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-tjtq1d92']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': '21T_Agilent'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-nstrhv39']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': '21T Agilent'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-nstrhv39']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': '7T_FT_ICR_MS'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-mwrrj632']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'Agilent_GC_MS_01'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-fas8ny90']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'Illumina HiSeq'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-79zxap02']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'Illumina HiSeq 2500-1TB'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-nn4b6k72']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'QExactP02'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-e32bpm65']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'QExactHF03'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-kw06tx33']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'Illumina NovaSeq S4'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-mr4r2w09']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'Illumina NovaSeq'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-xx07be40']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'Illumina NextSeq550'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-xz5tb342']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'NovaSeq SP'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-mr4r2w09']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'Illumina Illumina HiSeq'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-14-79zxap02']}
 
         Sanity tests related to `difflib`:
         >>> difflib.get_close_matches("a", ["ab", "cd"], n=1, cutoff=0.25)  # returns list containing the closest match

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
@@ -46,16 +46,23 @@ class Migrator(MigratorBase):
 
     def transform_instrument_slot(self, omics_doc: dict):
         r"""
-        Changes the instrument_name slot to be instrument_used, and replaces the name string value with an identifier for 
+        Changes the `instrument_name` slot to be `instrument_used`, and replaces the name string value with an identifier for 
         the instrument
 
         >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
         >>>
-        >>> database = {'instrument_set': [{'id': 'nmdc:inst-456', 'name': '12T FT-ICR MS', 'model':'solarix_12T', 'vendor':'bruker', 'type':'nmdc:Instrument'}]} 
+        >>> database = {
+        ...     'instrument_set': [
+        ...        {'id': 'nmdc:inst-456', 'name': '12T FT-ICR MS', 'model':'solarix_12T', 'vendor':'bruker', 'type':'nmdc:Instrument'},
+        ...        {'id': 'nmdc:inst-101', 'name': 'Illumina NovaSeq 6000', 'model':'my model', 'vendor':'my vendor', 'type':'nmdc:Instrument'},
+        ...     ]
+        ... } 
         >>> adapter = DictionaryAdapter(database=database)
         >>> m = Migrator(adapter=adapter)
         >>> m.transform_instrument_slot({'id': 'nmdc:omcp-123', 'instrument_name': '12T_FTICR_B'})
         {'id': 'nmdc:omcp-123', 'instrument_used': ['nmdc:inst-456']}
+        >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'NovaSeq X'})
+        {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-101']}
         """
 
         if "instrument_name" in omics_doc:

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
@@ -76,27 +76,27 @@ class Migrator(MigratorBase):
 
             if matches:
             
-                    # If the omics doc instrument_name has "NovaSeq" in its name but it doesn't end with "NovaSeq" (so has S4 or SP) map to Illumina NovaSeq 6000
-                    if "NovaSeq" in omics_doc['instrument_name'] and not omics_doc['instrument_name'].endswith("NovaSeq"):
-                        instrument_id = self.adapter.get_document_having_value_in_field(
-                              collection_name="instrument_set", field_name="name", value="Illumina NovaSeq 6000"
-                              )
-                         
-                        self.logger.info(f"instrument_name in {omics_doc['id']} is {omics_doc['instrument_name']} and will be matched to instrument with name Illumina NovaSeq 6000")
-
-                    else:
-                        # Match instrument_name with instrument set and get corresponding instrument id
-                        match = matches[0]
-                        self.logger.info(f"instrument_name in {omics_doc['id']} is {omics_doc['instrument_name']} and will be matched to instrument with name {match}")
+                # If the omics doc instrument_name has "NovaSeq" in its name but it doesn't end with "NovaSeq" (so has S4 or SP) map to Illumina NovaSeq 6000
+                if "NovaSeq" in omics_doc['instrument_name'] and not omics_doc['instrument_name'].endswith("NovaSeq"):
+                    instrument_id = self.adapter.get_document_having_value_in_field(
+                            collection_name="instrument_set", field_name="name", value="Illumina NovaSeq 6000"
+                            )
                         
-                        instrument = self.adapter.get_document_having_value_in_field(
-                            collection_name="instrument_set", field_name="name", value=match
-                        )
+                    self.logger.info(f"instrument_name in {omics_doc['id']} is {omics_doc['instrument_name']} and will be matched to instrument with name Illumina NovaSeq 6000")
 
-                        instrument_id = instrument.get("id")
+                else:
+                    # Match instrument_name with instrument set and get corresponding instrument id
+                    match = matches[0]
+                    self.logger.info(f"instrument_name in {omics_doc['id']} is {omics_doc['instrument_name']} and will be matched to instrument with name {match}")
                     
-                    omics_doc["instrument_used"] = [instrument_id]
-                    del omics_doc["instrument_name"]
+                    instrument = self.adapter.get_document_having_value_in_field(
+                        collection_name="instrument_set", field_name="name", value=match
+                    )
+
+                    instrument_id = instrument.get("id")
+                
+                omics_doc["instrument_used"] = [instrument_id]
+                del omics_doc["instrument_name"]
         
             else:
                 raise ValueError(f"The 'instrument_name' value ({existing_instrument_name}) "

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
@@ -75,27 +75,32 @@ class Migrator(MigratorBase):
             matches = difflib.get_close_matches(existing_instrument_name, allowed_instrument_names, n=1, cutoff=cutoff)
 
             if matches:
-            
-                # If the omics doc instrument_name has "NovaSeq" in its name but it doesn't end with "NovaSeq" (so has S4 or SP) map to Illumina NovaSeq 6000
-                if "NovaSeq" in omics_doc['instrument_name'] and not omics_doc['instrument_name'].endswith("NovaSeq"):
-                    instrument_id = self.adapter.get_document_having_value_in_field(
-                            collection_name="instrument_set", field_name="name", value="Illumina NovaSeq 6000"
-                            )
-                        
-                    self.logger.info(f"instrument_name in {omics_doc['id']} is {omics_doc['instrument_name']} and will be matched to instrument with name Illumina NovaSeq 6000")
+                allowed_instrument_name = matches[0]
 
-                else:
-                    # Match instrument_name with instrument set and get corresponding instrument id
-                    match = matches[0]
-                    self.logger.info(f"instrument_name in {omics_doc['id']} is {omics_doc['instrument_name']} and will be matched to instrument with name {match}")
-                    
+                # SPECIAL CASE: If the name of the original instrument contains—but does not end with—"NovaSeq",
+                #               (e.g. "NovaSeq S4" or "NovaSeq SP"), map it to "Illumina NovaSeq 6000".
+                if "NovaSeq" in omics_doc['instrument_name'] and not omics_doc['instrument_name'].endswith("NovaSeq"):
                     instrument = self.adapter.get_document_having_value_in_field(
-                        collection_name="instrument_set", field_name="name", value=match
+                        collection_name="instrument_set", field_name="name", value="Illumina NovaSeq 6000"
                     )
 
-                    instrument_id = instrument.get("id")
-                
+                    self.logger.info(f"'instrument_name' in '{omics_doc['id']}' is '{omics_doc['instrument_name']}' "
+                                     f"and will be mapped to instrument named 'Illumina NovaSeq 6000'")
+
+                else:
+                    # Use the allowed instrument whose name most closely matches the original instrument's name.
+                    self.logger.info(f"'instrument_name' in '{omics_doc['id']}' is '{omics_doc['instrument_name']}' "
+                                     f"and will be mapped to instrument named '{allowed_instrument_name}'")
+                    
+                    instrument = self.adapter.get_document_having_value_in_field(
+                        collection_name="instrument_set", field_name="name", value=allowed_instrument_name
+                    )
+
+                # Map the Omics document to the allowed instrument.
+                instrument_id = instrument.get("id")
                 omics_doc["instrument_used"] = [instrument_id]
+
+                # Delete the obsolete field from the Omics document.
                 del omics_doc["instrument_name"]
         
             else:

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_08.py
@@ -63,6 +63,7 @@ class Migrator(MigratorBase):
         {'id': 'nmdc:omcp-123', 'instrument_used': ['nmdc:inst-456']}
         >>> m.transform_instrument_slot({'id': 'nmdc:omcp-001', 'instrument_name': 'NovaSeq X'})
         {'id': 'nmdc:omcp-001', 'instrument_used': ['nmdc:inst-101']}
+        >>> matches = difflib.get_close_matches("a", ["a", "b"], n=1, cutoff=0.25)
         """
 
         if "instrument_name" in omics_doc:
@@ -71,11 +72,13 @@ class Migrator(MigratorBase):
             instruments = load_yaml_asset("migrator_from_10_2_0_to_11_0_0_part_08/instrument_set.yaml")
             allowed_instrument_names = [instrument["name"] for instrument in instruments]
 
+            # Determine which of the allowed instrument names most closely matches the "existing" (original) one.
+            # Reference: https://docs.python.org/3/library/difflib.html#difflib.get_close_matches
             cutoff = 0.25
             matches = difflib.get_close_matches(existing_instrument_name, allowed_instrument_names, n=1, cutoff=cutoff)
 
-            if matches:
-                allowed_instrument_name = matches[0]
+            if len(matches) > 0:
+                allowed_instrument_name = matches[0]  # this is the most closely-matching name
 
                 # SPECIAL CASE: If the name of the original instrument contains—but does not end with—"NovaSeq",
                 #               (e.g. "NovaSeq S4" or "NovaSeq SP"), map it to "Illumina NovaSeq 6000".


### PR DESCRIPTION
# Guidelines

## _Soft_ Schema Freeze

The `nmdc-schema` and `berkeley-schema-fy24` schemas are under a soft freeze, which means changes **should not** be made that have any downstream implications. To ensure this, all PRs created during the freeze will be closely reviewed with **every** component of the NMDC system in mind.

## Reviewers

To ensure no changes are made unexpectedly, PR creators will use this PR template to tag and notify all task coordinators. Review should be specifically requested from _all_ [Berkeley Schema Roll Out task coordinators](https://docs.google.com/document/d/1XXN1YuaBuSkxPXeiLKm5YxYzXTamBPQrzzeLhlh7PWs/edit#heading=h.u52g8v319adh) that you expect to be affected by this PR.

We expect task coordinators to review PRs and provide feedback/approval within 1 week of when they are identified as reviewers. 

PRs will **NOT** be merged until all task coordinators (or their delegates) have approved it; either here on GitHub (via "`Review changes` > `Approve`" or an equivalent comment) or verbally.

Expedition, questions, and discussion can happen at any meeting.

Delays in review & merging should be addressed in meetings or with NMDC leadership.

| If you expect the changes to<br>impact this component... | ...[request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)<br>from this person |
| -- | -- |
| Metadata<br>Schema | @mslarae13 |
| Runtime<br>Mongo database<br>Database migrations | @eecavanna,<br>who will pull in<br>@shreddd as needed |
| Postgres<br>Ingest | @naglepuff |
| Data Portal | @aclum |
| Workflows: MG & MT | @mbthornton-lbl |
| Workflows: MetaB & NOM | @corilo |
| Workflows: LipidO | @kheal |
| Workflows: MetaP | @SamuelPurvine |
| ETL code | @sujaypatil96 |
| Jupyter notebooks | @brynnz22 |

# PR Information

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation
- [ ] Schema change: Structure and content
  - created, updated, or deleted a `class`, `slot`, or `enum`
  - changed whether a `slot` is `multivalued`
  - changed the way a `slot` is assigned to a `class`
  - changed the `permissible_values` of an `enum`
  - _etc._
- [ ] Schema change: Cleanup and preparation
  - updated the description of a `class`, `slot`, or `enum`
  - updated the `mappings` of a `class`, `slot`, or `enum` to an ontology
  - added an `enum` for _future_ use (it is not in the `range` of any `slot`)
  - _etc._
     
## Description

This branch updates the instrument_set.yaml assets file for the Instrument migrator.

## Related Issues

> All PRs should relate to or fix an issue(s). Please identify the issue(s) below.

- Related Issue(s): #
- Fixes: #

## Did you add/update any tests?

- [ ] Yes
- [x] No _(Add a justification below)_
- [ ] I need help with writing tests

## Could this schema change make it so any valid data becomes invalid?

> This is a question about what the schema allows. It is not a question about what happens to exists in the NMDC database right now.
> 
> Example: If, in this PR branch, you renamed a `slot` from `foo` to `foo_bar`, the answer to this question would be "yes," **even if** nothing in the NMDC database _currently_ uses the `foo` `slot`.
>
> More examples: `slot` or `class` name changes, changes to a `slot`'s `multivalued` state, changes to a `slot`'s `range` (e.g. string to integer), changes to `slot` assignments to `class`es, changes to an `enum`'s `permissible_values`

- [ ] Yes _(A migrator is required)_
- [ ] No
- [x] I need help determining this
Need to test that migrator still works with the updated yaml
## If you answered "Yes", does this PR branch include that migrator?

- [ ] Yes
- [ ] No, this PR is incomplete and I need help writing the migrator

## Does this PR have any downstream implications?

> Examples: any change here that requires a change to workflows, workflow automation, the Mongo-to-Postgres ingest process, Jupyter notebooks, the Runtime, etc.

- [ ] Yes _(Explain below)_
- [x] No
