### PR TITLE
Add migrator to check and add `type` slot to `Protocol` records

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/__init__.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/__init__.py
@@ -18,6 +18,7 @@ from nmdc_schema.migrators.partials.migrator_from_10_2_0_to_11_0_0 import (
     migrator_from_10_2_0_to_11_0_0_part_14,
     migrator_from_10_2_0_to_11_0_0_part_15,
     migrator_from_10_2_0_to_11_0_0_part_16,
+    migrator_from_10_2_0_to_11_0_0_part_17,
 )
 
 def get_migrator_classes() -> List[Type[MigratorBase]]:
@@ -52,4 +53,5 @@ def get_migrator_classes() -> List[Type[MigratorBase]]:
         migrator_from_10_2_0_to_11_0_0_part_14.Migrator,
         migrator_from_10_2_0_to_11_0_0_part_15.Migrator,
         migrator_from_10_2_0_to_11_0_0_part_16.Migrator,
+        migrator_from_10_2_0_to_11_0_0_part_17.Migrator,
     ]

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
@@ -7,9 +7,7 @@ class Migrator(MigratorBase):
     """
 
     _from_version = "XX"
-    _to_version = "XX" #TODO KRH: add version number
-
-
+    _to_version = "PR250"
 
     def upgrade(self) -> None:
         r"""
@@ -44,3 +42,5 @@ class Migrator(MigratorBase):
         if "protocol_link" in document:
             if "type" not in document["protocol_link"]:
                 document["protocol_link"]["type"] = "nmdc:Protocol"
+
+        return document

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
@@ -31,7 +31,7 @@ class Migrator(MigratorBase):
     
     def add_type_to_protocol_link(self, document: dict) -> dict:
         r"""
-        Add a type slot on the Protocol class within the protocol_link slot on each document
+        Add a `type` field to the `Protocol` instance within the `protocol_link` field on each document.
 
         >>> m = Migrator()
         >>> m.add_type_to_protocol_link({'id': 123})  # no protocol_link field

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
@@ -17,10 +17,14 @@ class Migrator(MigratorBase):
         """
         # Add a type slot on the Protocol class within the protocol_link slot on each document
         collections_to_update = [
-            "material_processing_set",
             "data_generation_set",
-            "workflow_execution_set"
-        ] #TODOD KRH: check that these encapsulate all the collections that need to be updated
+            "material_processing_set",
+            "collecting_biosamples_from_site_set",
+            "protocol_execution_set",
+            "storage_process_set",
+            "workflow_execution_set",
+            "study_set"
+        ] 
 
         for collection_name in collections_to_update:
             self.adapter.process_each_document(collection_name, [self.add_type_to_protocol_link])

--- a/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
+++ b/nmdc_schema/migrators/partials/migrator_from_10_2_0_to_11_0_0/migrator_from_10_2_0_to_11_0_0_part_17.py
@@ -7,7 +7,7 @@ class Migrator(MigratorBase):
     """
 
     _from_version = "XX"
-    _to_version = "PR250"
+    _to_version = "FIXES_ISSUE_2180"
 
     def upgrade(self) -> None:
         r"""

--- a/src/data/invalid/LibraryPreparation-missing-protocol-type.yaml
+++ b/src/data/invalid/LibraryPreparation-missing-protocol-type.yaml
@@ -1,0 +1,12 @@
+# This record is missing the type field in the protocol_link slot
+end_date: '2017-12-12'
+has_input:
+- nmdc:procsm-12-px6qn983
+has_output:
+- nmdc:procsm-12-h63qmv56
+id: nmdc:libprp-12-1qp98z14
+processing_institution: Battelle
+start_date: 2014-08-05T18:40Z
+protocol_link:
+  name: BMI_metagenomicsSequencingSOP_v1
+type: nmdc:LibraryPreparation

--- a/src/data/valid/LibraryPreparation.yaml
+++ b/src/data/valid/LibraryPreparation.yaml
@@ -1,0 +1,13 @@
+# This record is missing the type field in the protocol_link slot
+end_date: '2017-12-12'
+has_input:
+- nmdc:procsm-12-px6qn983
+has_output:
+- nmdc:procsm-12-h63qmv56
+id: nmdc:libprp-12-1qp98z14
+processing_institution: Battelle
+start_date: 2014-08-05T18:40Z
+protocol_link:
+  name: BMI_metagenomicsSequencingSOP_v1
+  type: nmdc:Protocol
+type: nmdc:LibraryPreparation

--- a/src/data/valid/LibraryPreparation.yaml
+++ b/src/data/valid/LibraryPreparation.yaml
@@ -1,4 +1,3 @@
-# This record is missing the type field in the protocol_link slot
 end_date: '2017-12-12'
 has_input:
 - nmdc:procsm-12-px6qn983


### PR DESCRIPTION
  
## Description
This PR will add a migrator that will check the use of the `protocol_link` slot throughout the database and add the required `type` slot to its contents.

For example.  
This record is failing validation.
```
end_date: '2017-12-12'
has_input:
- nmdc:procsm-12-px6qn983
has_output:
- nmdc:procsm-12-h63qmv56
id: nmdc:libprp-12-1qp98z14
processing_institution: Battelle
start_date: 2014-08-05T18:40Z
protocol_link:
  name: BMI_metagenomicsSequencingSOP_v1
type: nmdc:LibraryPreparation
```
This PR will migrate it to this record:
```
end_date: '2017-12-12'
has_input:
- nmdc:procsm-12-px6qn983
has_output:
- nmdc:procsm-12-h63qmv56
id: nmdc:libprp-12-1qp98z14
processing_institution: Battelle
start_date: 2014-08-05T18:40Z
protocol_link:
  name: BMI_metagenomicsSequencingSOP_v1
  type: nmdc:Protocol
type: nmdc:LibraryPreparation
```

## Related Issues
- Fixes: https://github.com/microbiomedata/nmdc-schema/issues/2180

## Reviewers
To review: 
@eecavanna, @turbomam 

To keep informed:
@mslarae13, @naglepuff, @aclum, @mbthornton-lbl, @corilo, @SamuelPurvine, @brynnz22, @sujaypatil96

## What type of PR is this? (check all applicable)
- [X] Bug Fix _We missed a migrator, this PR will add it_

## Did you add/update any tests?

- [x] Yes
_Added doctest within migrator and added valid and invalid examples matching the examples above_

## Could this schema change make it so any valid data becomes invalid?
Not a schema change, just a migrator
- [X] No

## If you answered "Yes", does this PR branch include that migrator?
This PR is just a migrator

## Does this PR have any downstream implications?
- [X] No
