### PR TITLE
inlined-as-list-updates

### DIFF
--- a/assets/yq-for-mixs_subset_modified.txt
+++ b/assets/yq-for-mixs_subset_modified.txt
@@ -147,6 +147,7 @@
 '.slots.gravity.inlined_as_list |= true'
 '.slots.growth_hormone_regm.inlined_as_list |= true'
 '.slots.heavy_metals.inlined_as_list |= true'
+'.slots.heavy_metals_meth.inlined_as_list |= true'
 '.slots.herbicide_regm.inlined_as_list |= true'
 '.slots.host_diet.inlined_as_list |= true'
 '.slots.host_last_meal.inlined_as_list |= true'

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -4836,6 +4836,7 @@ slots:
     slot_uri: MIXS:0000343
     range: TextValue
     multivalued: false
+    inlined_as_list: true
   height_carper_fiber:
     annotations:
       expected_value:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -362,6 +362,7 @@ slots:
   has_peptide_quantifications:
     range: PeptideQuantification
     multivalued: true
+    inlined_as_list: true
 
   asm_score:
     is_a: metagenome_assembly_parameter

--- a/tests/test_all_multivalued_class_range_slots_are_inlined_as_list.py
+++ b/tests/test_all_multivalued_class_range_slots_are_inlined_as_list.py
@@ -1,0 +1,46 @@
+"""Data test."""
+import os
+import pprint
+import unittest
+
+from linkml_runtime import SchemaView
+from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.utils.schemaview import OrderedBy
+from linkml_runtime.linkml_model.meta import ClassDefinition
+
+ROOT = os.path.join(os.path.dirname(__file__), '..')
+SCHEMA_DIR = os.path.join(ROOT, "nmdc_schema")
+
+SCHEMA_FILE = os.path.join(SCHEMA_DIR, 'nmdc_materialized_patterns.yaml')
+
+
+class TestAllMultivaluedClassRangeSlotsAreInlinedAsList(unittest.TestCase):
+    """Test data and datamodel."""
+
+    def test_all_multivalued_class_range_slots_are_inlined_as_list(self):
+        view = SchemaView(SCHEMA_FILE)
+        print("\n")
+
+        all_class_names = list(view.all_classes(ordered_by=OrderedBy.LEXICAL).keys())
+
+        all_class_names.sort()
+
+        for current_class in all_class_names:
+            current_induced_class = view.induced_class(current_class)
+            current_induced_slots = current_induced_class.attributes
+
+            for sk, sv in sorted(current_induced_slots.items()):
+
+                if isinstance(view.get_element(sv.range), ClassDefinition) and sv.multivalued:
+
+                    # check if the class in the range has an identifiers slot
+                    range_identifier = view.get_identifier_slot(sv.range)
+
+                    if range_identifier is not None:
+                        pass
+                    else:
+                        print(
+                            f"{current_class}.{sk} is multivalued and has range {sv.range}, which does not have an identifying slot, so must be inlined_as_list")
+                        print(yaml_dumper.dumps(sv))
+                        self.assertTrue(sv.inlined_as_list,
+                                        f"{current_class}.{sk} is multivalued and has range {sv.range}, which does not have an identifying slot, so must be inlined_as_list")


### PR DESCRIPTION
This PR fixes two slots that should have been `inlined_as_list` (because they were `multivalued` and has a class in their range what doesn't have an identifier slot) but weren't

It also adds a Python test to detect that situation in the future

----

# Guidelines

## _Soft_ Schema Freeze

The `nmdc-schema` and `berkeley-schema-fy24` schemas are under a soft freeze, which means changes **should not** be made that have any downstream implications. To ensure this, all PRs created during the freeze will be closely reviewed with **every** component of the NMDC system in mind.

## Reviewers

To ensure no changes are made unexpectedly, PR creators will use this PR template to tag and notify all task coordinators. Review should be specifically requested from _all_ [Berkeley Schema Roll Out task coordinators](https://docs.google.com/document/d/1XXN1YuaBuSkxPXeiLKm5YxYzXTamBPQrzzeLhlh7PWs/edit#heading=h.u52g8v319adh) that you expect to be affected by this PR.

We expect task coordinators to review PRs and provide feedback/approval within 1 week of when they are identified as reviewers. 

PRs will **NOT** be merged until all task coordinators (or their delegates) have approved it; either here on GitHub (via "`Review changes` > `Approve`" or an equivalent comment) or verbally.

Expedition, questions, and discussion can happen at any meeting.

Delays in review & merging should be addressed in meetings or with NMDC leadership.

| If you expect the changes to<br>impact this component... | ...[request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)<br>from this person |
| -- | -- |
| Metadata<br>Schema | @mslarae13 |
| Runtime<br>Mongo database<br>Database migrations | @eecavanna,<br>who will pull in<br>@shreddd as needed |
| Postgres<br>Ingest | @naglepuff |
| Data Portal | @aclum |
| Workflows: MG & MT | @mbthornton-lbl |
| Workflows: MetaB & NOM | @corilo |
| Workflows: LipidO | @kheal |
| Workflows: MetaP | @SamuelPurvine |
| ETL code | @sujaypatil96 |
| Jupyter notebooks | @brynnz22 |

# PR Information

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation
- [ ] Schema change: Structure and content
  - created, updated, or deleted a `class`, `slot`, or `enum`
  - changed whether a `slot` is `multivalued`
  - changed the way a `slot` is assigned to a `class`
  - changed the `permissible_values` of an `enum`
  - _etc._
- [ ] Schema change: Cleanup and preparation
  - updated the description of a `class`, `slot`, or `enum`
  - updated the `mappings` of a `class`, `slot`, or `enum` to an ontology
  - added an `enum` for _future_ use (it is not in the `range` of any `slot`)
  - _etc._
     
## Description

> _PRs should be [small and concise](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs)._
>
> Aim to create small, focused pull requests that fulfill a single purpose. Smaller pull requests are easier and faster to review and merge, leave less room to introduce bugs, and provide a clearer history of changes.

- Replace this text with a description of what this PR branch contains. Please keep in mind that all reviewers will be reading this description. Example: "In this branch, I..."

## Related Issues

> All PRs should relate to or fix an issue(s). Please identify the issue(s) below.

- Related Issue(s): #
- Fixes: #

## Did you add/update any tests?

- [ ] Yes
- [x] No _(Add a justification below)_
- [ ] I need help with writing tests

## Could this schema change make it so any valid data becomes invalid?

> This is a question about what the schema allows. It is not a question about what happens to exists in the NMDC database right now.
> 
> Example: If, in this PR branch, you renamed a `slot` from `foo` to `foo_bar`, the answer to this question would be "yes," **even if** nothing in the NMDC database _currently_ uses the `foo` `slot`.
>
> More examples: `slot` or `class` name changes, changes to a `slot`'s `multivalued` state, changes to a `slot`'s `range` (e.g. string to integer), changes to `slot` assignments to `class`es, changes to an `enum`'s `permissible_values`

- [ ] Yes _(A migrator is required)_
- [ ] No
- [ ] I need help determining this

## If you answered "Yes", does this PR branch include that migrator?

- [ ] Yes
- [ ] No, this PR is incomplete and I need help writing the migrator

## Does this PR have any downstream implications?

> Examples: any change here that requires a change to workflows, workflow automation, the Mongo-to-Postgres ingest process, Jupyter notebooks, the Runtime, etc.

- [ ] Yes _(Explain below)_
- [x] No
